### PR TITLE
Discovery metadata

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.client;
 
-import java.net.URI;
-
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Default implementation of {@link ServiceInstance}.
@@ -26,6 +29,7 @@ import lombok.Data;
  * @author Spencer Gibb
  */
 @Data
+@RequiredArgsConstructor
 public class DefaultServiceInstance implements ServiceInstance {
 
 	private final String serviceId;
@@ -36,9 +40,20 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	private final boolean secure;
 
+	private final Map<String, String> metadata;
+
+	public DefaultServiceInstance(String serviceId, String host, int port, boolean secure) {
+		this(serviceId, host, port, secure, Collections.<String, String>emptyMap());
+	}
+
 	@Override
 	public URI getUri() {
 		return getUri(this);
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return metadata;
 	}
 
 	/**

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ServiceInstance.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.client;
 
 import java.net.URI;
+import java.util.Map;
 
 /**
  * Represents an instance of a Service in a Discovery System
@@ -27,23 +28,30 @@ public interface ServiceInstance {
 	/**
 	 * @return the service id as register by the DiscoveryClient
 	 */
-	public String getServiceId();
+	String getServiceId();
 
 	/**
 	 * @return the hostname of the registered ServiceInstance
 	 */
-	public String getHost();
+	String getHost();
 
 	/**
 	 * @return the port of the registered ServiceInstance
 	 */
-	public int getPort();
+	int getPort();
 
 	/**
-	 * @return ifthe port of the registered ServiceInstance is https or not
+	 * @return if the port of the registered ServiceInstance is https or not
 	 */
-	public boolean isSecure();
+	boolean isSecure();
 
-	public URI getUri();
+	/**
+	 * @return the service uri address
+	 */
+	URI getUri();
 
+	/**
+	 * @return the key value pair metadata associated with the service instance
+	 */
+	Map<String, String> getMetadata();
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
@@ -16,13 +16,7 @@
 
 package org.springframework.cloud.client.discovery.noop;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
-import javax.annotation.PostConstruct;
-
 import lombok.extern.apachecommons.CommonsLog;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
@@ -39,6 +33,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
+
+import javax.annotation.PostConstruct;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 /**
  * @author Dave Syer
@@ -71,8 +69,8 @@ public class NoopDiscoveryClientAutoConfiguration implements
 			log.error("Cannot get host info", e);
 		}
 		int port = findPort();
-		this.serviceInstance = new DefaultServiceInstance(this.environment.getProperty(
-				"spring.application.name", "application"), host, port, false);
+		this.serviceInstance = new DefaultServiceInstance(
+				this.environment.getProperty("spring.application.name", "application"), host, port, false);
 	}
 
 	private int findPort() {


### PR DESCRIPTION
This pull request introduces the metadata map that can be associated with each service instance registered within discovery service (currently covered by Eureka and Zookeper, Consul is planned to have such support in version 2.0) allowing to use that information on the client side.

I had to also align the version with latest spring boot snapshot where some class has been renamed, this is way there are two commits.