### PR TITLE
Fixes GH-62

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
@@ -145,7 +145,6 @@ public class BootstrapApplicationListener
 			}
 		}
 		if (!installed) {
-			application.setRegisterShutdownHook(false);
 			application.addInitializers(new AncestorInitializer(context));
 		}
 


### PR DESCRIPTION
Disabling the shutdown hook of the child application is not necessary anymore, since the shutdown hook is not set by the parent context anymore.