### PR TITLE
Polish doc

### DIFF
--- a/docs/src/main/asciidoc/jce.adoc
+++ b/docs/src/main/asciidoc/jce.adoc
@@ -1,7 +1,7 @@
 If you are getting an exception due to "Illegal key size" and you are using Sun's JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files. See the following links for more information:
 
-* Java 6 JCE Link http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html
-* Java 7 JCE Link http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
-* Java 8 JCE Link http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html
+* http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html[Java 6 JCE]
+* http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html[Java 7 JCE]
+* http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java 8 JCE]
 
 Extract files into JDK/jre/lib/security folder (whichever version of JRE/JDK x64/x86 you are using).

--- a/docs/src/main/asciidoc/spring-cloud-commons.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-commons.adoc
@@ -1,12 +1,13 @@
 = Cloud Native Applications
-:github: https://github.com/spring-cloud/spring-cloud-commons
+:githubroot: https://github.com/spring-cloud
+:github: {githubroot}/spring-cloud-commons
 :githubmaster: {github}/tree/master
 :docslink: {githubmaster}/docs/src/main/asciidoc
 :toc:
 
 include::intro.adoc[]
 
-include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/docs/src/main/asciidoc/contributing-docs.adoc[]
+include::https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/contributing-docs.adoc[]
 
 == Spring Cloud Context: Application Context Services
 
@@ -272,7 +273,7 @@ classpath (Maven co-ordinates
 "org.springframework.security:spring-security-rsa") and you also need
 the full strength JCE extensions in your JVM.
 
-include::jce.adoc
+include::jce.adoc[]
 
 === Endpoints
 
@@ -308,7 +309,7 @@ public class MyClass {
 
 The URI needs to use a virtual host name (ie. service name, not a host name).
 The Ribbon client is used to create a full physical address. See
-{github-code}/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java[RibbonAutoConfiguration]
+{githubroot}/spring-cloud-netflix/blob/master/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java[RibbonAutoConfiguration]
 for details of how the `RestTemplate` is set up.
 
 === Multiple RestTemplate objects


### PR DESCRIPTION
I did not manage to fix the include for `https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/contributing-docs.adoc` which still show up as plain text in the generated doc.

Maybe the `RibbonAutoConfiguration` reference is a bit out of place in an introduction?