### PR TITLE
Added support for service IP address

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -38,14 +38,22 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	private final int port;
 
+	private final String address;
+
 	private final boolean secure;
 
 	private final Map<String, String> metadata;
 
 	public DefaultServiceInstance(String serviceId, String host, int port,
 			boolean secure) {
-		this(serviceId, host, port, secure, new LinkedHashMap<String, String>());
+		this(serviceId, host, port, null, secure, new LinkedHashMap<String, String>());
 	}
+
+	public DefaultServiceInstance(String serviceId, String host, int port, String address,
+								  boolean secure) {
+		this(serviceId, host, port, address, secure, new LinkedHashMap<String, String>());
+	}
+
 
 	@Override
 	public URI getUri() {

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ServiceInstance.java
@@ -41,6 +41,11 @@ public interface ServiceInstance {
 	int getPort();
 
 	/**
+	 * @return the IP address of the registered ServiceInstance
+	 */
+	String getAddress();
+
+	/**
 	 * @return if the port of the registered ServiceInstance is https or not
 	 */
 	boolean isSecure();

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
@@ -64,15 +64,17 @@ public class NoopDiscoveryClientAutoConfiguration implements
 	@PostConstruct
 	public void init() {
 		String host = "localhost";
+		String address = "127.0.0.1";
 		try {
 			host = InetAddress.getLocalHost().getHostName();
+			address = InetAddress.getLocalHost().getHostAddress();
 		}
 		catch (UnknownHostException e) {
 			log.error("Cannot get host info", e);
 		}
 		int port = findPort();
 		this.serviceInstance = new DefaultServiceInstance(this.environment.getProperty(
-				"spring.application.name", "application"), host, port, false);
+				"spring.application.name", "application"), host, port, address, false);
 	}
 
 	private int findPort() {

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfigurationTest.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfigurationTest.java
@@ -1,0 +1,43 @@
+package org.springframework.cloud.client.discovery.noop;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class NoopDiscoveryClientAutoConfigurationTest {
+
+    @InjectMocks
+    private NoopDiscoveryClientAutoConfiguration target;
+
+    @Mock
+    private Environment env;
+
+    @Test
+    public void defaultValues() throws UnknownHostException {
+
+        when(env.getProperty("spring.application.name", "application")).thenReturn("name");
+
+        target.init();
+
+        ServiceInstance serviceInstance = (ServiceInstance) ReflectionTestUtils.getField(target, "serviceInstance");
+
+        assertEquals(InetAddress.getLocalHost().getHostName(), serviceInstance.getHost());
+        assertEquals(InetAddress.getLocalHost().getHostAddress(), serviceInstance.getAddress());
+        assertEquals("name", serviceInstance.getServiceId());
+
+    }
+
+}


### PR DESCRIPTION
I need the ability to retrieve the IP address of a service instance in Consul, so the first part of the change I need to make to Spring Cloud Consul is to add the required "address" field to org.springframework.cloud.client.ServiceInstance.