### PR TITLE
Fix property source for decrypted variables

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -33,10 +33,10 @@ import org.springframework.core.Ordered;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
-import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 /**
@@ -96,7 +96,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 			// We have some decrypted properties
 			found.addAll(map.keySet());
 			insert(applicationContext,
-					new MapPropertySource(DECRYPTED_PROPERTY_SOURCE_NAME, map));
+					new SystemEnvironmentPropertySource(DECRYPTED_PROPERTY_SOURCE_NAME, map));
 		}
 		PropertySource<?> bootstrap = propertySources
 				.get(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME);
@@ -104,7 +104,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 			map = decrypt(bootstrap);
 			if (!map.isEmpty()) {
 				found.addAll(map.keySet());
-				insert(applicationContext, new MapPropertySource(
+				insert(applicationContext, new SystemEnvironmentPropertySource(
 						DECRYPTED_BOOTSTRAP_PROPERTY_SOURCE_NAME, map));
 			}
 		}
@@ -121,7 +121,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 	}
 
 	private void insert(ApplicationContext applicationContext,
-			MapPropertySource propertySource) {
+			SystemEnvironmentPropertySource propertySource) {
 		ApplicationContext parent = applicationContext;
 		while (parent != null) {
 			if (parent.getEnvironment() instanceof ConfigurableEnvironment) {
@@ -134,7 +134,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 	}
 
 	private void insert(MutablePropertySources propertySources,
-			MapPropertySource propertySource) {
+			SystemEnvironmentPropertySource propertySource) {
 		if (propertySources
 				.contains(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME)) {
 			if (DECRYPTED_BOOTSTRAP_PROPERTY_SOURCE_NAME


### PR DESCRIPTION
This fixes the issue described at #87.

When resolving a property that comes as an environment variable and is encrypted (MY_PASSWORD={cipher}ahsbcssb235563ssc), [PropertySourcesPropertyResolver](https://github.com/spring-projects/spring-framework/blob/64ce8a81c3f6d5ef99ee6cd8220e3c8ad9e5f846/spring-core/src/main/java/org/springframework/core/env/PropertySourcesPropertyResolver.java) searches for the properties in the ``decrypted`` property source. 

The decrypted property (MY_PASSWORD) is not found, however, because [MapPropertySource](https://github.com/spring-projects/spring-framework/blob/d5ee787e1e6653257720afe31ee3f8819cd4605c/spring-core/src/main/java/org/springframework/core/env/MapPropertySource.java) doesn't have an implementation to solve relaxed binding. This leads PropertySourcesPropertyResolver to move on and find ``MY_PASSWORD`` in the ``systemEnvironment`` property source, which still has the encrypted value.

Changing ``EnvironmentDecryptApplicationInitializer`` implementation to use a ``SystemEnvironmentPropertySource`` internally enables it to lookup property names that use relaxed binding. 