### PR TITLE
Catch and log exceptions that occur when attempting to deregister a s…

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/AbstractDiscoveryLifecycle.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/AbstractDiscoveryLifecycle.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.client.discovery;
 
-import javax.annotation.PreDestroy;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
@@ -26,6 +26,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.Environment;
 
+import javax.annotation.PreDestroy;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,6 +36,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public abstract class AbstractDiscoveryLifecycle implements DiscoveryLifecycle,
 		ApplicationContextAware, ApplicationListener<EmbeddedServletContainerInitializedEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractDiscoveryLifecycle.class);
 
 	private boolean autoStartup = true;
 
@@ -74,7 +77,11 @@ public abstract class AbstractDiscoveryLifecycle implements DiscoveryLifecycle,
 
 	@Override
 	public void stop(Runnable callback) {
-		stop();
+		try {
+			stop();
+		} catch (Exception e) {
+			logger.error("A problem occurred attempting to stop discovery lifecycle", e);
+		}
 		callback.run();
 	}
 


### PR DESCRIPTION
…ervice during shutdown.

Currently, if an exception is thrown when deregistering the service (maybe the registry is not available) the latch used by the DefaultLifecycleProcessor is not decremented and you have to wait for the latch timeout (30 seconds) for shutdown to complete. With this fix, the exception is logged and normal shutdown execution continues.