### PR TITLE
Support meaningful discovery instance id in containerized envrionment

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ContainerProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ContainerProperties.java
@@ -1,0 +1,55 @@
+package org.springframework.cloud.client.discovery;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
+
+/**
+ * Container related properties which can be useful context of discovery
+ *
+ * @author Stefan Gross
+ *
+ */
+@ConfigurationProperties(ContainerProperties.PREFIX)
+public class ContainerProperties {
+
+    public static final String PREFIX = "spring.cloud.container";
+    private final Environment environment;
+
+
+    /**
+     * Port number to which server.port is mapped in host of container
+     *
+     * Used for creating a more meaningful instance id without massive changes
+     * No other function at the moment
+     *
+     */
+    @Value("${spring.cloud.container.hostPort:$CONTAINER_HOST_PORT}")
+    private Integer hostPort;
+
+
+
+    private ContainerProperties() {
+        this.environment = null; // never called
+    }
+
+
+    public ContainerProperties(Environment environment) {
+        this.environment = environment;
+
+    }
+
+    public Integer getHostPort() {
+        return hostPort;
+    }
+
+    public void setHostPort(Integer hostPort) {
+        this.hostPort = hostPort;
+    }
+
+    @Override
+    public String toString() {
+        return "ContainerProperties [hostPort=" + this.hostPort + "]";
+    }
+
+}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
@@ -23,8 +23,12 @@ public class IdUtils {
 
 		String namePart = combineParts(hostname, SEPARATOR, appName);
 
+		// in a containerized environment, it makes more sense to build the
+		// instance id with the mapped port than the container internal server.port
+		String containerHostPort = relaxed.getProperty("spring.cloud.container.hostPort");
 		String indexPart = relaxed.getProperty("spring.application.instance_id",
-				relaxed.getProperty("server.port"));
+				containerHostPort!=null?containerHostPort:relaxed.getProperty("server.port"));
+
 
 		return combineParts(namePart, SEPARATOR, indexPart);
 	}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/IdUtilsTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/IdUtilsTests.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.cloud.client.discovery.ContainerProperties;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -70,9 +71,9 @@ public class IdUtilsTests {
 
 	@Test
 	public void portWorks() {
-		this.env.setProperty("spring.application.name", DEFAULT_ID);
+		this.env.setProperty("server.port", "80");
 		String instanceId = IdUtils.getDefaultInstanceId(this.env);
-		assertEquals("instanceId was wrong", DEFAULT_ID, instanceId);
+		assertEquals("instanceId was wrong", "80", instanceId);
 	}
 
 	@Test
@@ -81,6 +82,15 @@ public class IdUtilsTests {
 		this.env.setProperty("server.port", "80");
 		String instanceId = IdUtils.getDefaultInstanceId(this.env);
 		assertEquals("instanceId was wrong", DEFAULT_ID+":80", instanceId);
+	}
+
+	@Test
+	public void should_useMappedContainerPort_whenProvided() {
+		this.env.setProperty("spring.application.name", DEFAULT_ID);
+		this.env.setProperty("server.port", "80");
+		this.env.setProperty(ContainerProperties.PREFIX+".hostPort", "8080");
+		String instanceId = IdUtils.getDefaultInstanceId(this.env);
+		assertEquals("instanceId was wrong", DEFAULT_ID+":8080", instanceId);
 	}
 
 	@Test


### PR DESCRIPTION
In containerized environment we cannot use server.port, when having
more than one service instances running on one host. Introduce first
container related property to build a instance id with mapped host port
to be registered in discovery