### PR TITLE
Allow lifecycle endpoints to be globally disabled

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/restart/RestartEndpoint.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/restart/RestartEndpoint.java
@@ -114,6 +114,7 @@ public class RestartEndpoint extends AbstractEndpoint<Boolean>
 		return new ResumeEndpoint();
 	}
 
+	@ConfigurationProperties("endpoints")
 	public class PauseEndpoint extends AbstractEndpoint<Boolean> {
 
 		public PauseEndpoint() {
@@ -130,6 +131,7 @@ public class RestartEndpoint extends AbstractEndpoint<Boolean>
 		}
 	}
 
+	@ConfigurationProperties("endpoints")
 	public class ResumeEndpoint extends AbstractEndpoint<Boolean> {
 
 		public ResumeEndpoint() {

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
@@ -1,5 +1,10 @@
 package org.springframework.cloud.autoconfigure;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Test;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -9,11 +14,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Spencer Gibb
@@ -43,6 +43,21 @@ public class LifecycleMvcAutoConfigurationTests {
 	@Test
 	public void restartMvcEndpointDisabled() {
 		endpointDisabled("endpoints.restart.enabled", "restartMvcEndpoint");
+	}
+	
+	@Test
+	public void pauseMvcEndpointGloballyDisabled() {
+		endpointDisabled("endpoints.enabled", "pauseMvcEndpoint");
+	}
+	
+	@Test
+	public void resumeMvcEndpointGloballyDisabled() {
+		endpointDisabled("endpoints.enabled", "resumeMvcEndpoint");
+	}
+	
+	@Test
+	public void restartMvcEndpointGloballyDisabled() {
+		endpointDisabled("endpoints.enabled", "restartMvcEndpoint");
 	}
 
 	private void endpointDisabled(String enabledProp, String beanName) {


### PR DESCRIPTION
Currently, turning off lifecycle endpoints does not work with the `endpoints.enabled` property. This means the lifecycle endpoints have to be individually disabled 

```
endpoints:
   enabled: false
pause:
   enabled: false
restart:
   enabled: false
resume:
   enabled: false
```

This change allows the lifecycle endpoints observe the `endpoints.enabled` property