### PR TITLE
fixed : Retrying Failed Requests' property is wrong

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-commons.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-commons.adoc
@@ -363,7 +363,7 @@ for details of how the `RestTemplate` is set up.
 
 A load balanced `RestTemplate` can be configured to retry failed requests.
 By default this logic is disabled, you can enable it by setting
-`spring.cloud.loadbalancer.retry=true`.  The load balanced `RestTemplate` will
+`spring.cloud.loadbalancer.retry.enabled=true`.  The load balanced `RestTemplate` will
 honor some of the Ribbon configuration values related to retrying failed requests.
 The properties you can use are `client.ribbon.MaxAutoRetries`,
 `client.ribbon.MaxAutoRetriesNextServer`, and `client.ribbon.OkToRetryOnAllOperations`.


### PR DESCRIPTION
When I set `spring.cloud.loadbalancer.retry=true`,  it is not working. 

According to the source,  `spring.cloud.loadbalancer.retry.enabled=true` is right.

```java
@ConfigurationProperties("spring.cloud.loadbalancer.retry")
public class LoadBalancerRetryProperties {
    private boolean enabled = false;
    ....
}
```