### PR TITLE
Add support for looking up services by metadata in DiscoveryClient

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/AbstractDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/AbstractDiscoveryClient.java
@@ -1,0 +1,19 @@
+package org.springframework.cloud.client.discovery;
+
+import org.springframework.cloud.client.ServiceInstance;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract implementation of DiscoveryClient to ease introduction of new methods in the future. This will avoid having
+ * to update all implements every time a new method is added to the interface.
+ */
+public abstract class AbstractDiscoveryClient implements DiscoveryClient {
+
+    /** Default implementation which ignores metadata for unsupported DiscoveryClient's */
+    public List<ServiceInstance> getInstances(String serviceId, Map<String, String> metadata) {
+        return getInstances(serviceId);
+    }
+
+}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
@@ -50,6 +50,10 @@ public interface DiscoveryClient {
 
 	/**
 	 * Get all ServiceInstances associated with a particular serviceId that match the provided metadata
+	 *
+	 * Note that not all implementations support metadata, so some or all of the metadata provided may
+	 * be ignored when looking up a service.
+	 *
 	 * @param serviceId the serviceId to query
 	 * @param metadata metadata to use in constraining the search
 	 * @return a List of ServiceInstance

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.client.discovery;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.client.ServiceInstance;
 
@@ -46,6 +47,14 @@ public interface DiscoveryClient {
 	 * @return a List of ServiceInstance
 	 */
 	List<ServiceInstance> getInstances(String serviceId);
+
+	/**
+	 * Get all ServiceInstances associated with a particular serviceId that match the provided metadata
+	 * @param serviceId the serviceId to query
+	 * @param metadata metadata to use in constraining the search
+	 * @return a List of ServiceInstance
+	 */
+	List<ServiceInstance> getInstances(String serviceId, Map<String, String> metadata);
 
 	/**
 	 * @return all known service ids

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClient.java
@@ -20,13 +20,14 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.AbstractDiscoveryClient;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 
 /**
  * DiscoveryClient used when no implementations are found on the classpath
  * @author Dave Syer
  */
-public class NoopDiscoveryClient implements DiscoveryClient {
+public class NoopDiscoveryClient extends AbstractDiscoveryClient {
 
 	private final ServiceInstance instance;
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientConfigurationAdditionalTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientConfigurationAdditionalTests.java
@@ -1,6 +1,7 @@
 package org.springframework.cloud.client.discovery.noop;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,11 @@ public class NoopDiscoveryClientConfigurationAdditionalTests {
 
 				@Override
 				public List<ServiceInstance> getInstances(String serviceId) {
+					return null;
+				}
+
+				@Override
+				public List<ServiceInstance> getInstances(String serviceId, Map<String, String> metadata) {
 					return null;
 				}
 


### PR DESCRIPTION
Added a new getInstances() method to DiscoveryClient, which also accepts metadata. This can be used, for example, to lookup a service with a given tag in Consul. Also added AbstractDiscoveryClient to minimize the impact of future enhancements to DiscoveryClient, so that all implementation will no longer need to be updated.

This change will require corresponding changes to all the existing implementations.