### PR TITLE
GH-178: Fixes edge case of a infinite loop in decrypting properties

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,8 +129,8 @@ public class EnvironmentDecryptApplicationInitializer implements
 				ConfigurableEnvironment mutable = (ConfigurableEnvironment) parent
 						.getEnvironment();
 				insert(mutable.getPropertySources(), propertySource);
-				parent = parent.getParent();
 			}
+			parent = parent.getParent();
 		}
 	}
 
@@ -235,11 +235,6 @@ public class EnvironmentDecryptApplicationInitializer implements
 
 		}
 
-	}
-
-	class DecryptResult {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		boolean hasEncryptedProperties = false;
 	}
 
 }

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -129,72 +129,7 @@ public class EnvironmentDecryptApplicationInitializerTests {
 
 
 		ApplicationContext ctxParent = mock(ApplicationContext.class);
-		when(ctxParent.getEnvironment()).thenReturn(new Environment() {
-			@Override
-			public String[] getActiveProfiles() {
-				return new String[0];
-			}
-
-			@Override
-			public String[] getDefaultProfiles() {
-				return new String[0];
-			}
-
-			@Override
-			public boolean acceptsProfiles(String... profiles) {
-				return false;
-			}
-
-			@Override
-			public boolean containsProperty(String key) {
-				return false;
-			}
-
-			@Override
-			public String getProperty(String key) {
-				return null;
-			}
-
-			@Override
-			public String getProperty(String key, String defaultValue) {
-				return null;
-			}
-
-			@Override
-			public <T> T getProperty(String key, Class<T> targetType) {
-				return null;
-			}
-
-			@Override
-			public <T> T getProperty(String key, Class<T> targetType, T defaultValue) {
-				return null;
-			}
-
-			@Override
-			public <T> Class<T> getPropertyAsClass(String key, Class<T> targetType) {
-				return null;
-			}
-
-			@Override
-			public String getRequiredProperty(String key) throws IllegalStateException {
-				return null;
-			}
-
-			@Override
-			public <T> T getRequiredProperty(String key, Class<T> targetType) throws IllegalStateException {
-				return null;
-			}
-
-			@Override
-			public String resolvePlaceholders(String text) {
-				return null;
-			}
-
-			@Override
-			public String resolveRequiredPlaceholders(String text) throws IllegalArgumentException {
-				return null;
-			}
-		});
+		when(ctxParent.getEnvironment()).thenReturn(mock(Environment.class));
 
 		ctx.setParent(ctxParent);
 


### PR DESCRIPTION
Fixes #178 : Edge case where if there is a parent context which returns an environment that is not a `ConfigurableEnvironment`, can lead to an infinite loop.