### PR TITLE
GH-184: To support eagerly creating the set of child contexts

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
@@ -67,6 +67,12 @@ public abstract class NamedContextFactory<C extends NamedContextFactory.Specific
 		return new HashSet<>(contexts.keySet());
 	}
 
+	protected void createAndCacheContexts() {
+		for (String key: this.configurations.keySet()) {
+			getContext(key);
+		}
+	}
+
 	@Override
 	public void destroy() {
 		Collection<AnnotationConfigApplicationContext> values = this.contexts.values();

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -25,6 +25,7 @@ import org.springframework.core.env.MapPropertySource;
  *
  * @author Spencer Gibb
  * @author Dave Syer
+ * @author Biju Kunjummen
  */
 public abstract class NamedContextFactory<C extends NamedContextFactory.Specification>
 		implements DisposableBean, ApplicationContextAware {
@@ -67,6 +68,9 @@ public abstract class NamedContextFactory<C extends NamedContextFactory.Specific
 		return new HashSet<>(contexts.keySet());
 	}
 
+	/**
+	 * Eagerly create and cache the  contexts based on the stored Spring Configurations
+	 */
 	protected void createAndCacheContexts() {
 		for (String key: this.configurations.keySet()) {
 			getContext(key);

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/named/NamedContextFactoryTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/named/NamedContextFactoryTests.java
@@ -62,6 +62,18 @@ public class NamedContextFactoryTests {
 		assertThat("bar context wasn't closed", barContext.isActive(), is(false));
 	}
 
+	@Test
+	public void testEagerlyCreateContexts() {
+		TestClientFactory factory = new TestClientFactory();
+		factory.setConfigurations(Arrays.asList(getSpec("foo", FooConfig.class),
+				getSpec("bar", BarConfig.class)));
+		factory.createAndCacheContexts();
+
+		Foo foo = factory.getInstance("foo", Foo.class);
+		assertThat("foo was null", foo, is(notNullValue()));
+
+	}
+
 	private TestSpec getSpec(String name, Class<?> configClass) {
 		return new TestSpec(name, new Class[]{configClass});
 	}


### PR DESCRIPTION
Fixes: #184 
Downstream Issue: https://github.com/spring-cloud/spring-cloud-netflix/issues/1334

* Provides a base method for eagerly instantiating all the contexts registered in `NamedContextFactory`.  The expectation is that `SpringClientFactory` in spring-cloud-netflix project will invoke this to instantiate all ribbon clients on application startup.