### PR TITLE
Add option to control management registration

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
@@ -2,15 +2,10 @@ package org.springframework.cloud.client.serviceregistry;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import lombok.Getter;
-import lombok.Setter;
-
 /**
  * @author Spencer Gibb
  */
 @ConfigurationProperties("spring.cloud.service-registry.auto-registration")
-@Getter
-@Setter
 public class AutoServiceRegistrationProperties {
 
 	/** If Auto-Service Registration is enabled, default to true. */
@@ -19,7 +14,22 @@ public class AutoServiceRegistrationProperties {
 	/** Whether to register the management as a service, defaults to true */
 	private boolean registerManagement = true;
 
+	public boolean shouldRegisterManagement() {
+		return registerManagement;
+	}
+
+	public void setRegisterManagement(boolean registerManagement) {
+		this.registerManagement = registerManagement;
+	}
+
 	/** Should startup fail if there is no AutoServiceRegistration, default to false. */
 	private boolean failFast = false;
 
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
@@ -2,23 +2,24 @@ package org.springframework.cloud.client.serviceregistry;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @author Spencer Gibb
  */
 @ConfigurationProperties("spring.cloud.service-registry.auto-registration")
+@Getter
+@Setter
 public class AutoServiceRegistrationProperties {
 
 	/** If Auto-Service Registration is enabled, default to true. */
 	private boolean enabled = true;
 
+	/** Whether to register the management as a service, defaults to true */
+	private boolean registerManagement = true;
+
 	/** Should startup fail if there is no AutoServiceRegistration, default to false. */
 	private boolean failFast = false;
 
-	public boolean isFailFast() {
-		return failFast;
-	}
-
-	public void setFailFast(boolean failFast) {
-		this.failFast = failFast;
-	}
 }


### PR DESCRIPTION
In continuation of [this PR to spring-cloud-consul](https://github.com/spring-cloud/spring-cloud-consul/pull/323), I've added option to control management registration to spring-cloud-commons.