### PR TITLE
Fix empty keys in EnvironmentChangedEvent on resetting the Environment

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/environment/EnvironmentManager.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/environment/EnvironmentManager.java
@@ -68,9 +68,8 @@ public class EnvironmentManager implements ApplicationEventPublisherAware {
 	public Map<String, Object> reset() {
 		Map<String, Object> result = new LinkedHashMap<String, Object>(map);
 		if (!map.isEmpty()) {
-			Set<String> keys = map.keySet();
 			map.clear();
-			publish(new EnvironmentChangeEvent(keys));
+			publish(new EnvironmentChangeEvent(result.keySet()));
 		}
 		return result;
 	}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/environment/EnvironmentManagerTest.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/environment/EnvironmentManagerTest.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.context.environment;
+
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class EnvironmentManagerTest {
+
+    @Test
+    public void testCorrectEvents() {
+        MockEnvironment environment = new MockEnvironment();
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        EnvironmentManager environmentManager = new EnvironmentManager(environment);
+        environmentManager.setApplicationEventPublisher(publisher);
+
+        environmentManager.setProperty("foo", "bar");
+
+        assertThat(environment.getProperty("foo")).isEqualTo("bar");
+        ArgumentCaptor<ApplicationEvent> eventCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);
+        verify(publisher, times(1)).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(EnvironmentChangeEvent.class);
+        EnvironmentChangeEvent event = (EnvironmentChangeEvent) eventCaptor.getValue();
+        assertThat(event.getKeys()).containsExactly("foo");
+
+        reset(publisher);
+
+        environmentManager.reset();
+        assertThat(environment.getProperty("foo")).isNull();
+        verify(publisher, times(1)).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(EnvironmentChangeEvent.class);
+        event = (EnvironmentChangeEvent) eventCaptor.getValue();
+        assertThat(event.getKeys()).containsExactly("foo");
+    }
+
+}


### PR DESCRIPTION
When the Environment is resetted the EnvironmentChangedEvent always
contains an empty keySet, since the live view of the cleared map was
used. This commit fixes this.