### PR TITLE
Show better message for missing config keystore props

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfiguration.java
@@ -63,15 +63,20 @@ public class EncryptionBootstrapConfiguration {
 		@ConditionalOnMissingBean(TextEncryptor.class)
 		public TextEncryptor textEncryptor() {
 			KeyStore keyStore = this.key.getKeyStore();
-			if (keyStore.getLocation() != null && keyStore.getLocation().exists()) {
-				return new RsaSecretEncryptor(
-						new KeyStoreKeyFactory(keyStore.getLocation(),
-								keyStore.getPassword().toCharArray()).getKeyPair(
-										keyStore.getAlias(),
-										keyStore.getSecret().toCharArray()),
-						this.key.getRsa().getAlgorithm(), this.key.getRsa().getSalt(),
-						this.key.getRsa().isStrong());
+			if (keyStore.getLocation() != null) {
+				if (keyStore.getLocation().exists()) {
+					return new RsaSecretEncryptor(
+							new KeyStoreKeyFactory(keyStore.getLocation(),
+									keyStore.getPassword().toCharArray()).getKeyPair(
+									keyStore.getAlias(),
+									keyStore.getSecret().toCharArray()),
+							this.key.getRsa().getAlgorithm(), this.key.getRsa().getSalt(),
+							this.key.getRsa().isStrong());
+				} 
+				
+				throw new IllegalStateException("Invalid keystore location");
 			}
+			
 			return new EncryptorFactory().create(this.key.getKey());
 		}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfigurationTests.java
@@ -1,13 +1,19 @@
 package org.springframework.cloud.bootstrap.encrypt;
 
-import static org.junit.Assert.assertEquals;
-
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 public class EncryptionBootstrapConfigurationTests {
+
+	@Rule
+	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void rsaKeyStore() {
@@ -33,6 +39,25 @@ public class EncryptionBootstrapConfigurationTests {
 		TextEncryptor encryptor = context.getBean(TextEncryptor.class);
 		assertEquals("foo", encryptor.decrypt(encryptor.encrypt("foo")));
 		context.close();
+	}
+
+	@Test
+	public void nonExistentKeystoreLocationShouldNotBeAllowed() {
+		try {
+			new SpringApplicationBuilder(EncryptionBootstrapConfiguration.class)
+					.web(false)
+					.properties("encrypt.key-store.location:classpath:/server.jks1",
+							"encrypt.key-store.password:letmein",
+							"encrypt.key-store.alias:mytestkey",
+							"encrypt.key-store.secret:changeme")
+					.run();
+			assertThat(false)
+					.as("Should not create an application context with invalid keystore location")
+					.isTrue();
+		}
+		catch (Exception e) {
+			assertThat(e).hasRootCauseInstanceOf(IllegalStateException.class);
+		}
 	}
 
 }

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfigurationTests.java
@@ -1,8 +1,6 @@
 package org.springframework.cloud.bootstrap.encrypt;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
@@ -11,9 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class EncryptionBootstrapConfigurationTests {
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void rsaKeyStore() {


### PR DESCRIPTION
Fixes #230  - Throws an `IllegalStateException` if the keystore location is present but wrong. The second requested issue of handling a case where key is null does not happen as `KeyCondition` would fail.