### PR TITLE
Support resettable configuration properties

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ package org.springframework.cloud.autoconfigure;
 import java.util.Collections;
 
 import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetaData;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessorRegistrar;
@@ -35,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnBean(ConfigurationPropertiesBindingPostProcessor.class)
+@AutoConfigureAfter(ConfigurationPropertiesAutoConfiguration.class)
 public class ConfigurationPropertiesRebinderAutoConfiguration
 		implements ApplicationContextAware, SmartInitializingSingleton {
 

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/environment/EnvironmentChangeEvent.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/environment/EnvironmentChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,16 +24,24 @@ import org.springframework.core.env.Environment;
  * Event published to signal a change in the {@link Environment}.
  * 
  * @author Dave Syer
+ * @author Biju Kunjummen
  *
  */
 @SuppressWarnings("serial")
 public class EnvironmentChangeEvent extends ApplicationEvent {
 
-	private Set<String> keys;
+	private final Set<String> keys;
+	
+	private final ChangeType changeType;
 
 	public EnvironmentChangeEvent(Set<String> keys) {
+		this(keys, ChangeType.ADD_UPDATE);
+	}
+	
+	public EnvironmentChangeEvent(Set<String> keys, ChangeType changeType) {
 		super(keys);
 		this.keys = keys;
+		this.changeType = changeType;
 	}
 	
 	/**
@@ -41,6 +49,23 @@ public class EnvironmentChangeEvent extends ApplicationEvent {
 	 */
 	public Set<String> getKeys() {
 		return keys;
+	}
+
+	/**
+	 * The type of change to the environment.
+	 * Defaults to add/update
+	 * 
+	 * @return change type 
+	 */
+	public ChangeType getChangeType() {
+		return this.changeType;
+	}
+
+	/**
+	 * Represents the type of change for the set of keys.
+	 */
+	public enum ChangeType {
+		ADD_UPDATE, DELETE
 	}
 
 }

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/PropertiesResettable.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/PropertiesResettable.java
@@ -1,0 +1,13 @@
+package org.springframework.cloud.context.properties;
+
+/**
+ * To indicate that a {@link org.springframework.boot.context.properties.ConfigurationProperties} annotated bean
+ * can fields can be reset - this is useful for cases where properties are removed from the environment
+ */
+public interface PropertiesResettable {
+
+	/**
+	 * Reset the fields 
+	 */
+	void reset();
+}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
@@ -54,7 +54,7 @@ public class ContextRefresher {
 		addConfigFilesToEnvironment();
 		Set<String> keys = changes(before,
 				extract(this.context.getEnvironment().getPropertySources())).keySet();
-		this.context.publishEvent(new EnvironmentChangeEvent(keys));
+		this.context.publishEvent(new EnvironmentChangeEvent(keys, EnvironmentChangeEvent.ChangeType.DELETE));
 		this.scope.refreshAll();
 		return keys;
 	}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRemoveTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRemoveTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.context.properties;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * To test behavior of Configuration properties with properties removed
+ * 
+ * @author Biju Kunjummen
+ */
+
+public class ConfigurationPropertiesRemoveTests {
+
+	@Test
+	public void shouldBindNewPropertiesToConfigurationPropertiesBean() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(ctx, "testprops.messages[0]=msg0",
+				"testprops.messages[1]=msg1", "testprops.mapMessages.key1=val1",
+				"testprops.mapMessages.key2=val2");
+		ctx.register(TestConfiguration.class);
+		ctx.refresh();
+
+		TestProperties testProperties = ctx.getBean(TestProperties.class);
+
+		assertThat(testProperties.getMessages()).containsExactly("msg0", "msg1");
+		assertThat(testProperties.getMapMessages()).containsOnlyKeys("key1", "key2");
+
+		EnvironmentTestUtils.addEnvironment(ctx, "testprops.messages[2]=msg2",
+				"testprops.mapMessages.key3=val3");
+
+		ctx.publishEvent(new EnvironmentChangeEvent(
+				new HashSet<>(Arrays.asList("testprops.messages"))));
+
+		assertThat(testProperties.getMessages()).containsExactly("msg0", "msg1", "msg2");
+		assertThat(testProperties.getMapMessages()).containsOnlyKeys("key1", "key2", "key3");
+	}
+
+	@Test
+	public void shouldRemovePropertiesFromConfigurationPropertiesBean() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(ctx, "testprops.messages[0]=msg0",
+				"testprops.messages[1]=msg1", "testprops.mapMessages.key1=val1",
+				"testprops.mapMessages.key2=val2");
+		ctx.register(TestConfiguration.class);
+		ctx.refresh();
+
+		TestProperties testProperties = ctx.getBean(TestProperties.class);
+
+		assertThat(testProperties.getMessages()).containsExactly("msg0", "msg1");
+		assertThat(testProperties.getMapMessages()).containsOnlyKeys("key1", "key2");
+
+		removeEnv(ctx.getEnvironment(), "testprops.mapMessages.key2");
+
+		ctx.publishEvent(new EnvironmentChangeEvent(
+				new HashSet<>(Arrays.asList("testprops.mapMessages.key2")), EnvironmentChangeEvent.ChangeType.DELETE));
+
+		assertThat(testProperties.getMessages()).containsExactly("msg0", "msg1");
+		assertThat(testProperties.getMapMessages()).containsOnlyKeys("key1");
+	}
+
+	private void removeEnv(ConfigurableEnvironment environment, String... keys) {
+		MutablePropertySources sources = environment.getPropertySources();
+		Map<String, Object> map = (Map<String, Object>) sources.get("test").getSource();
+		for (String key : keys) {
+			map.remove(key);
+		}
+	}
+
+	@Configuration
+	@Import({ ConfigurationPropertiesAutoConfiguration.class,
+			ConfigurationPropertiesRebinderAutoConfiguration.class})
+	protected static class TestConfiguration {
+
+		@Bean
+		protected TestProperties properties() {
+			return new TestProperties();
+		}
+
+	}
+
+	@ConfigurationProperties(prefix = "testprops")
+	protected static class TestProperties implements PropertiesResettable {
+		private List<String> messages;
+		private Map<String, String> mapMessages = new HashMap<>();
+
+		public List<String> getMessages() {
+			return this.messages;
+		}
+
+		public void setMessages(List<String> messages) {
+			this.messages = messages;
+		}
+
+		public Map<String, String> getMapMessages() {
+			return mapMessages;
+		}
+
+		public void setMapMessages(Map<String, String> mapMessages) {
+			this.mapMessages = mapMessages;
+		}
+
+		@Override
+		public void reset() {
+			this.messages = new ArrayList<>();
+			this.mapMessages = new HashMap<>();
+		}
+	}
+
+}


### PR DESCRIPTION
@spencergibb , @dsyer, @ryanjbaxter - this is more a POC to support the issues that we had discussed about PR https://github.com/spring-cloud/spring-cloud-netflix/pull/2158. 

One of the underlying issue is that any `@ConfigurationProperties` annotated bean supports refreshing of new properties or update of existing properties, but if properties are deleted it is not accounted for - this is because the previously bound bean is retrieved and re-bound with the properties again and existing state remains. This PR tries to fix it by introducing a `PropertiesResettable` interface - if a `@ConfigurationProperties` annotated class implements this interface then the internal state can be reset by `reset()` method which the bean is expected to implement. 

Can you please review and see if this approach looks okay - it does behave like `@RefreshScope` though, so any feedback on how to better implement this is welcome.

If this approach works then I can as a follow up work on the PR on the s-c-netflix side to fix ZuulHandlerMapping on ZuulProperties route deletion.