### PR TITLE
serviceRegistry should set to final to make code more clear

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -14,7 +14,7 @@ import org.springframework.cloud.client.discovery.AbstractDiscoveryLifecycle;
 @SuppressWarnings("deprecation")
 public abstract class AbstractAutoServiceRegistration<R extends Registration> extends AbstractDiscoveryLifecycle implements AutoServiceRegistration {
 
-	private ServiceRegistry<R> serviceRegistry;
+	private final ServiceRegistry<R> serviceRegistry;
 
 	protected AbstractAutoServiceRegistration(ServiceRegistry<R> serviceRegistry) {
 		this.serviceRegistry = serviceRegistry;


### PR DESCRIPTION
In AbstractAutoServiceRegistration, I suggest to set the property serviceRegistry as final to make code more clear.