### PR TITLE
move property definition to begin of class to improve code style

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -14,7 +14,7 @@ import org.springframework.cloud.client.discovery.AbstractDiscoveryLifecycle;
 @SuppressWarnings("deprecation")
 public abstract class AbstractAutoServiceRegistration<R extends Registration> extends AbstractDiscoveryLifecycle implements AutoServiceRegistration {
 
-	private ServiceRegistry<R> serviceRegistry;
+	private final ServiceRegistry<R> serviceRegistry;
 
 	protected AbstractAutoServiceRegistration(ServiceRegistry<R> serviceRegistry) {
 		this.serviceRegistry = serviceRegistry;

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationProperties.java
@@ -14,6 +14,9 @@ public class AutoServiceRegistrationProperties {
 	/** Whether to register the management as a service, defaults to true */
 	private boolean registerManagement = true;
 
+	/** Should startup fail if there is no AutoServiceRegistration, default to false. */
+	private boolean failFast = false;
+
 	public boolean shouldRegisterManagement() {
 		return registerManagement;
 	}
@@ -21,9 +24,6 @@ public class AutoServiceRegistrationProperties {
 	public void setRegisterManagement(boolean registerManagement) {
 		this.registerManagement = registerManagement;
 	}
-
-	/** Should startup fail if there is no AutoServiceRegistration, default to false. */
-	private boolean failFast = false;
 
 	public boolean isFailFast() {
 		return failFast;


### PR DESCRIPTION
In class AutoServiceRegistrationProperties, the property failFast is defined after some methodes. 

This is not a good code style and I suggest to move it to the begin of the class and before all the methods.