### PR TITLE
Check for any AOP-Proxy in ConfigurationPropertiesRebinder

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -93,7 +93,7 @@ public class ConfigurationPropertiesRebinder
 		if (this.applicationContext != null) {
 			try {
 				Object bean = this.applicationContext.getBean(name);
-				if (AopUtils.isCglibProxy(bean)) {
+				if (AopUtils.isAopProxy(bean)) {
 					bean = getTargetObject(bean);
 				}
 				this.applicationContext.getAutowireCapableBeanFactory().destroyBean(bean);


### PR DESCRIPTION
Fixes #288 - PostProcessor getting applied more than once to the same bean.

#288 Might need more research, this is my naive fix of the problem. Please review carefully.