### PR TITLE
fix(CONTRIBUTING.MD): fix links on contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,15 +9,14 @@ follow the guidelines below.
 
 ## Sign the Contributor License Agreement
 Before we accept a non-trivial patch or pull request we will need you to sign the
-https://cla.pivotal.io/sign/spring[Contributor License Agreement].
+[Contributor License Agreement](https://cla.pivotal.io/sign/spring).
 Signing the contributor's agreement does not grant anyone commit rights to the main
 repository, but it does mean that we can accept your contributions, and you will get an
 author credit if we do.  Active contributors might be asked to join the core team, and
 given the ability to merge pull requests.
 
 ## Code of Conduct
-This project adheres to the Contributor Covenant https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/code-of-conduct.adoc[code of
-conduct]. By participating, you  are expected to uphold this code. Please report
+This project adheres to the Contributor Covenant [code of conduct](https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/code-of-conduct.adoc). By participating, you  are expected to uphold this code. Please report
 unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 ## Code Conventions and Housekeeping
@@ -26,22 +25,20 @@ added after the original pull request but before a merge.
 
 * Use the Spring Framework code format conventions. If you use Eclipse
   you can import formatter settings using the
-  `eclipse-code-formatter.xml` file from the
-  https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
-  Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
-  Plugin] to import the same file.
+  `eclipse-code-formatter.xml` file from the [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
+  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same 
+  file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
 * Add the ASF license header comment to all new `.java` files (copy from existing files
   in the project)
-* Add yourself as an `@author` to the .java files that you modify substantially (more
+* Add yourself as an `@author` to the `.java` files that you modify substantially (more
   than cosmetic changes).
 * Add some Javadocs and, if you change the namespace, some XSD doc elements.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
-  message (where XXXX is the issue number).
+  message (where `XXXX` is the issue number).


### PR DESCRIPTION
Found few minor issues in the [CONTRIBUTING.MD](https://github.com/spring-cloud/spring-cloud-commons/blob/master/.github/CONTRIBUTING.md) while going through this document.

Changes:
- Fix broken links

Team please review.