### PR TITLE
Fix for preferred address list

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/InetUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/InetUtils.java
@@ -28,7 +28,12 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/InetUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/InetUtils.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.commons.util;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -24,15 +27,8 @@ import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Enumeration;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.util.List;
+import java.util.concurrent.*;
 
 /**
  * @author Spencer Gibb
@@ -99,7 +95,7 @@ public class InetUtils implements Closeable {
 							InetAddress address = addrs.nextElement();
 							if (address instanceof Inet4Address
 									&& !address.isLoopbackAddress()
-									&& !ignoreAddress(address)) {
+									&& isPreferredAddress(address)) {
 								log.trace("Found non-loopback interface: "
 										+ ifc.getDisplayName());
 								result = address;
@@ -128,19 +124,26 @@ public class InetUtils implements Closeable {
 		return null;
 	}
 
-	/** for testing */ boolean ignoreAddress(InetAddress address) {
+	/** for testing */ boolean isPreferredAddress(InetAddress address) {
 
-		if (this.properties.isUseOnlySiteLocalInterfaces() && !address.isSiteLocalAddress()) {
-			log.trace("Ignoring address: " + address.getHostAddress());
+		if (this.properties.isUseOnlySiteLocalInterfaces()) {
+			final boolean siteLocalAddress = address.isSiteLocalAddress();
+			if (!siteLocalAddress) {
+				log.trace("Ignoring address: " + address.getHostAddress());
+			}
+			return siteLocalAddress;
+		}
+		final List<String> preferredNetworks = this.properties.getPreferredNetworks();
+		if (preferredNetworks.isEmpty()) {
 			return true;
 		}
-	
-		for (String regex : this.properties.getPreferredNetworks()) {
-		if (!address.getHostAddress().matches(regex) && !address.getHostAddress().startsWith(regex)) {
-			log.trace("Ignoring address: " + address.getHostAddress());
+		for (String regex : preferredNetworks) {
+			final String hostAddress = address.getHostAddress();
+			if (hostAddress.matches(regex) || hostAddress.startsWith(regex)) {
 				return true;
 			}
 		}
+		log.trace("Ignoring address: " + address.getHostAddress());
 		return false;
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/InetUtilsTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/InetUtilsTests.java
@@ -23,7 +23,9 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/InetUtilsTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/InetUtilsTests.java
@@ -16,15 +16,14 @@
 
 package org.springframework.cloud.commons.util;
 
-import java.net.InetAddress;
-import java.util.Arrays;
-
 import org.junit.Test;
 import org.springframework.cloud.commons.util.InetUtils.HostInfo;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Dave Syer
@@ -55,7 +54,7 @@ public class InetUtilsTests {
 	}
 
 	@Test
-	public void testHostInfo() throws Exception {
+	public void testHostInfo() {
 		try (InetUtils utils = new InetUtils(new InetUtilsProperties())) {
 			HostInfo info = utils.findFirstNonLoopbackHostInfo();
 			assertNotNull(info.getIpAddressAsInt());
@@ -92,30 +91,46 @@ public class InetUtilsTests {
 		properties.setUseOnlySiteLocalInterfaces(true);
 
 		try (InetUtils utils = new InetUtils(properties)) {
-			assertFalse(utils.ignoreAddress(InetAddress.getByName("192.168.0.1")));
-			assertTrue(utils.ignoreAddress(InetAddress.getByName("5.5.8.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("192.168.0.1")));
+			assertFalse(utils.isPreferredAddress(InetAddress.getByName("5.5.8.1")));
 		}
 	}
 	
 	@Test
-	public void testPrefferedNetworksRegex() throws Exception {
+	public void testPreferredNetworksRegex() throws Exception {
 		InetUtilsProperties properties = new InetUtilsProperties();
-		properties.setPreferredNetworks(Arrays.asList("192.168.*"));
+		properties.setPreferredNetworks(Arrays.asList("192.168.*", "10.0.*"));
 
 		try (InetUtils utils = new InetUtils(properties)) {
-			assertFalse(utils.ignoreAddress(InetAddress.getByName("192.168.0.1")));
-			assertTrue(utils.ignoreAddress(InetAddress.getByName("5.5.8.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("192.168.0.1")));
+			assertFalse(utils.isPreferredAddress(InetAddress.getByName("5.5.8.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("10.0.10.1")));
+			assertFalse(utils.isPreferredAddress(InetAddress.getByName("10.255.10.1")));
 		}
 	}
 	
 	@Test
-	public void testPrefferedNetworksSimple() throws Exception {
+	public void testPreferredNetworksSimple() throws Exception {
 		InetUtilsProperties properties = new InetUtilsProperties();
-		properties.setPreferredNetworks(Arrays.asList("192"));
-		
+		properties.setPreferredNetworks(Arrays.asList("192", "10.0"));
+
 		try (InetUtils utils = new InetUtils(properties)) {
-			assertFalse(utils.ignoreAddress(InetAddress.getByName("192.168.0.1")));
-			assertTrue(utils.ignoreAddress(InetAddress.getByName("5.5.8.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("192.168.0.1")));
+			assertFalse(utils.isPreferredAddress(InetAddress.getByName("5.5.8.1")));
+			assertFalse(utils.isPreferredAddress(InetAddress.getByName("10.255.10.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("10.0.10.1")));
+		}
+	}
+
+	@Test
+	public void testPreferredNetworksListIsEmpty() throws Exception {
+		InetUtilsProperties properties = new InetUtilsProperties();
+		properties.setPreferredNetworks(Collections.emptyList());
+		try (InetUtils utils = new InetUtils(properties)) {
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("192.168.0.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("5.5.8.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("10.255.10.1")));
+			assertTrue(utils.isPreferredAddress(InetAddress.getByName("10.0.10.1")));
 		}
 	}
 }


### PR DESCRIPTION
InetUtils doesn't work correctly with list of preferred addresses because it continue iterate throughs list of preferred addresses even when predicate for preferred address gives positive result and stop iterate on negative result only.  

So we have 2 cases:

- Preferred addresses are [192, 10], address for test is 10.x.x.x
`!address.getHostAddress().matches("10") && !address.getHostAddress().startsWith("10")` will pass and iteration will be stoped.
- Preferred addresses are [192, 10], address for test is 192.x.x.x
In first iteration 
`!address.getHostAddress().matches("192") && !address.getHostAddress().startsWith("192)` will not pass and iteration will continue.
In second iteration 
`!address.getHostAddress().matches("10") && !address.getHostAddress().startsWith("10)` will pass and iteration will be stoped with invalid result.