### PR TITLE
Polish RefreshScopeBeanDefinitionEnhancer.setRefreshable()

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
@@ -102,8 +102,8 @@ public class RefreshAutoConfiguration {
 		public void setRefreshable(Set<String> refreshables) {
 			if (this.refreshables != refreshables) {
 				this.refreshables.clear();
+				this.refreshables.addAll(refreshables);
 			}
-			this.refreshables.addAll(refreshables);
 		}
 
 		public void setExtraRefreshable(Set<String> refreshables) {


### PR DESCRIPTION
If `this.refreshables` and `refreshables` are the same instance, invoking `addAll()` isn't necessary.