### PR TITLE
1.3.x

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.4.RELEASE</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Docs</name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.5.BUILD-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Docs</name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.RELEASE</version>
+		<version>1.3.4.BUILD-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Docs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-commons-parent</artifactId>
-	<version>1.3.4.BUILD-SNAPSHOT</version>
+	<version>1.3.4.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Parent</name>
 	<description>Spring Cloud Commons Parent</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.8.RELEASE</version>
+		<version>1.3.10.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-commons-parent</artifactId>
-	<version>1.3.4.RELEASE</version>
+	<version>1.3.4.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Parent</name>
 	<description>Spring Cloud Commons Parent</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.10.RELEASE</version>
+		<version>1.3.8.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-commons-parent</artifactId>
-	<version>1.3.4.BUILD-SNAPSHOT</version>
+	<version>1.3.5.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Commons Parent</name>
 	<description>Spring Cloud Commons Parent</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.8.RELEASE</version>
+		<version>1.3.10.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-commons-dependencies/pom.xml
+++ b/spring-cloud-commons-dependencies/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.3.8.BUILD-SNAPSHOT</version>
+		<version>1.3.10.RELEASE</version>
         <relativePath/>
 	</parent>
 	<artifactId>spring-cloud-commons-dependencies</artifactId>
-	<version>1.3.4.BUILD-SNAPSHOT</version>
+	<version>1.3.5.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-commons-dependencies</name>
 	<description>Spring Cloud Commons Dependencies</description>

--- a/spring-cloud-commons-dependencies/pom.xml
+++ b/spring-cloud-commons-dependencies/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.3.10.RELEASE</version>
+		<version>1.3.8.BUILD-SNAPSHOT</version>
         <relativePath/>
 	</parent>
 	<artifactId>spring-cloud-commons-dependencies</artifactId>
-	<version>1.3.4.RELEASE</version>
+	<version>1.3.4.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-commons-dependencies</name>
 	<description>Spring Cloud Commons Dependencies</description>

--- a/spring-cloud-commons-dependencies/pom.xml
+++ b/spring-cloud-commons-dependencies/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.3.8.BUILD-SNAPSHOT</version>
+		<version>1.3.10.RELEASE</version>
         <relativePath/>
 	</parent>
 	<artifactId>spring-cloud-commons-dependencies</artifactId>
-	<version>1.3.4.BUILD-SNAPSHOT</version>
+	<version>1.3.4.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-commons-dependencies</name>
 	<description>Spring Cloud Commons Dependencies</description>

--- a/spring-cloud-commons/pom.xml
+++ b/spring-cloud-commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.RELEASE</version>
+		<version>1.3.4.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-commons</artifactId>

--- a/spring-cloud-commons/pom.xml
+++ b/spring-cloud-commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.5.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-commons</artifactId>

--- a/spring-cloud-commons/pom.xml
+++ b/spring-cloud-commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.4.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-commons</artifactId>

--- a/spring-cloud-context/pom.xml
+++ b/spring-cloud-context/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.4.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-context</artifactId>

--- a/spring-cloud-context/pom.xml
+++ b/spring-cloud-context/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.5.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-context</artifactId>

--- a/spring-cloud-context/pom.xml
+++ b/spring-cloud-context/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.RELEASE</version>
+		<version>1.3.4.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-context</artifactId>

--- a/spring-cloud-starter/pom.xml
+++ b/spring-cloud-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.RELEASE</version>
+		<version>1.3.4.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter</artifactId>
 	<name>spring-cloud-starter</name>

--- a/spring-cloud-starter/pom.xml
+++ b/spring-cloud-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.5.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter</artifactId>
 	<name>spring-cloud-starter</name>

--- a/spring-cloud-starter/pom.xml
+++ b/spring-cloud-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-commons-parent</artifactId>
-		<version>1.3.4.BUILD-SNAPSHOT</version>
+		<version>1.3.4.RELEASE</version>
 	</parent>
 	<artifactId>spring-cloud-starter</artifactId>
 	<name>spring-cloud-starter</name>


### PR DESCRIPTION
In spring-cloud2.0, Consul as a server, and the project runs in tomcat, but consul can't find the service. By tracing the code, AbstractAutoServiceRegistration.bind()  executed by listening to the WebServerInitializedEvent, but  WebServerInitializedEvent is not happended during the boot process.  

Starting through the Main method service is OK.

My current solution is listening HeartbeatEvent and then call consulAutoServiceRegistration.start ().It works.
