### PR TITLE
Make decryption code fail-fast AFTER logging the error.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -198,14 +198,14 @@ public class EnvironmentDecryptApplicationInitializer implements
 						}
 						catch (Exception e) {
 							String message = "Cannot decrypt: key=" + key;
-							if (this.failOnError) {
-								throw new IllegalStateException(message, e);
-							}
 							if (logger.isDebugEnabled()) {
 								logger.warn(message, e);
 							}
 							else {
 								logger.warn(message);
+							}
+							if (this.failOnError) {
+								throw new IllegalStateException(message, e);
 							}
 							// Set value to empty to avoid making a password out of the
 							// cipher text

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -96,7 +96,7 @@ public class EnvironmentDecryptApplicationInitializerTests {
 		// Assert logs contain warning even when exception thrown
 		String sysOutput = this.outputCapture.toString();
 		assertThat("Decryption error log message missing", sysOutput, containsString(
-				"EnvironmentDecryptApplicationInitializer - Cannot decrypt: key=foo"));
+				"Cannot decrypt: key=foo"));
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class EnvironmentDecryptApplicationInitializerTests {
 		// Assert logs contain warning
 		String sysOutput = this.outputCapture.toString();
 		assertThat("Decryption error log message missing", sysOutput, containsString(
-				"EnvironmentDecryptApplicationInitializer - Cannot decrypt: key=foo"));
+				"Cannot decrypt: key=foo"));
 		// Empty is safest fallback for undecryptable cipher
 		assertEquals("", context.getEnvironment().getProperty("foo"));
 	}


### PR DESCRIPTION
This was driving me crazy recently trying to debug code running on my server that was set to failOnError=true, which was covering up any logging of the actual error message in the logs. Would love to get this fixed unless there is a good reason not to do it. Thanks!