### PR TITLE
Refactor String#replaceAll

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/encrypt/EncryptorFactory.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/encrypt/EncryptorFactory.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.context.encrypt;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.regex.Pattern;
 
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.MiscPEMGenerator;
@@ -36,6 +37,8 @@ import org.springframework.security.rsa.crypto.RsaSecretEncryptor;
  */
 public class EncryptorFactory {
 
+	private static final Pattern NEWLINE_ESCAPE_PATTERN = Pattern.compile("\\r|\\n");
+
 	private String salt = "deadbeef";
 
 	public EncryptorFactory() {
@@ -53,7 +56,7 @@ public class EncryptorFactory {
 			try {
 				String normalizedPemData = normalizePem(data);
 				encryptor = new RsaSecretEncryptor(
-						normalizedPemData.replaceAll("\\n", "").replaceAll("\\r", ""));
+						NEWLINE_ESCAPE_PATTERN.matcher(normalizedPemData).replaceAll(""));
 			}
 			catch (IllegalArgumentException e) {
 				throw new KeyFormatException(e);


### PR DESCRIPTION
If we repeatedly call String#replaceAll, we internally repeatedly call the regular expression pattern compilation every time as following:
```java
    public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```
The modifications are to keep the compiled pattern.
Therefore, compiling a relatively expensive regular expression pattern does not have to be done every time.