### PR TITLE
Allow overriding encrypted properties with unencrypted properties

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -225,9 +225,12 @@ public class EnvironmentDecryptApplicationInitializer implements
 						}
 					}
 					else if (COLLECTION_PROPERTY.matcher(key).matches()) {
-						// put non-ecrypted properties so merging of index properties
+						// put non-encrypted properties so merging of index properties
 						// happens correctly
 						otherCollectionProperties.put(key, value);
+					}
+					else {
+						overrides.remove(key);
 					}
 				}
 			}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -78,6 +78,17 @@ public class EnvironmentDecryptApplicationInitializerTests {
 		assertEquals("spam", context.getEnvironment().getProperty("foo"));
 	}
 
+	@Test
+	public void propertySourcesOrderedCorrectlyWithUnencryptedOverrides() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext();
+		TestPropertyValues.of("foo: {cipher}bar").applyTo(context);
+		context.getEnvironment().getPropertySources()
+				.addFirst(new MapPropertySource("test_override",
+						Collections.<String, Object>singletonMap("foo", "spam")));
+		this.listener.initialize(context);
+		assertEquals("spam", context.getEnvironment().getProperty("foo"));
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void errorOnDecrypt() {
 		this.listener = new EnvironmentDecryptApplicationInitializer(


### PR DESCRIPTION
Since the decrypted property source is taking precedence over all other property sources, it would not allow encrypted properties to be overridden by unencrypted properties. This commit removes the decrypted property from the overrides if it gets overridden by an unencrypted property.