### PR TITLE
Only attempt to decrypt properties that are not overridden

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -163,21 +163,25 @@ public class EnvironmentDecryptApplicationInitializer implements
 			sources.add(0, source);
 		}
 		for (PropertySource<?> source : sources) {
-			decrypt(source, overrides);
+			collectEncryptedProperties(source, overrides);
 		}
+
+		doDecrypt(overrides);
 		return overrides;
 	}
 
 	private Map<String, Object> decrypt(PropertySource<?> source) {
 		Map<String, Object> overrides = new LinkedHashMap<>();
-		decrypt(source, overrides);
+		collectEncryptedProperties(source, overrides);
+		doDecrypt(overrides);
 		return overrides;
 	}
 
 	private static final Pattern COLLECTION_PROPERTY = Pattern
 			.compile("(\\S+)?\\[(\\d+)\\](\\.\\S+)?");
 
-	private void decrypt(PropertySource<?> source, Map<String, Object> overrides) {
+	private void collectEncryptedProperties(PropertySource<?> source,
+			Map<String, Object> overrides) {
 
 		if (source instanceof EnumerablePropertySource) {
 			Map<String, Object> otherCollectionProperties = new LinkedHashMap<>();
@@ -189,28 +193,6 @@ public class EnvironmentDecryptApplicationInitializer implements
 				if (property != null) {
 					String value = property.toString();
 					if (value.startsWith("{cipher}")) {
-						value = value.substring("{cipher}".length());
-						try {
-							value = this.encryptor.decrypt(value);
-							if (logger.isDebugEnabled()) {
-								logger.debug("Decrypted: key=" + key);
-							}
-						}
-						catch (Exception e) {
-							String message = "Cannot decrypt: key=" + key;
-							if (this.failOnError) {
-								throw new IllegalStateException(message, e);
-							}
-							if (logger.isDebugEnabled()) {
-								logger.warn(message, e);
-							}
-							else {
-								logger.warn(message);
-							}
-							// Set value to empty to avoid making a password out of the
-							// cipher text
-							value = "";
-						}
 						overrides.put(key, value);
 						if (COLLECTION_PROPERTY.matcher(key).matches()) {
 							sourceHasDecryptedCollection = true;
@@ -236,11 +218,42 @@ public class EnvironmentDecryptApplicationInitializer implements
 
 			for (PropertySource<?> nested : ((CompositePropertySource) source)
 					.getPropertySources()) {
-				decrypt(nested, overrides);
+				collectEncryptedProperties(nested, overrides);
 			}
 
 		}
 
+	}
+
+	private void doDecrypt(Map<String, Object> overrides) {
+		for (String key : overrides.keySet()) {
+			String value = overrides.get(key).toString();
+			if (value.startsWith("{cipher}")) {
+				value = value.substring("{cipher}".length());
+				try {
+					value = this.encryptor.decrypt(value);
+					if (logger.isDebugEnabled()) {
+						logger.debug("Decrypted: key=" + key);
+					}
+				}
+				catch (Exception e) {
+					String message = "Cannot decrypt: key=" + key;
+					if (this.failOnError) {
+						throw new IllegalStateException(message, e);
+					}
+					if (logger.isDebugEnabled()) {
+						logger.warn(message, e);
+					}
+					else {
+						logger.warn(message);
+					}
+					// Set value to empty to avoid making a password out of the
+					// cipher text
+					value = "";
+				}
+				overrides.put(key, value);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
Since decryption can be expensive (e.g. an http request needs to be made) or just not possible (in tests), it can be beneficial to not attempt to decrypt properties that get overridden anyway.

In this PR the decryption is postponed until after all the overrides are gathered.

Side effect is that `failOnError` will only fail if the property does not get overridden.