### PR TITLE
Provide exact error when there is a problem opening the logging config file.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
@@ -134,8 +134,7 @@ public class PropertySourceBootstrapConfiguration implements
 			}
 			catch (Exception ex) {
 				PropertySourceBootstrapConfiguration.logger
-						.warn("Logging config file location '" + logConfig
-								+ "' cannot be opened and will be ignored");
+						.warn("Error opening logging config file " + logConfig, ex);
 			}
 		}
 	}


### PR DESCRIPTION
  Fixes #464