### PR TITLE
Do not remove property from overrides if already decrypted. Fixes #471

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -208,7 +208,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 						// put non-encrypted properties so merging of index properties
 						// happens correctly
 						otherCollectionProperties.put(key, value);
-					} else {
+					} else if (!enumerable.getName().equals(DECRYPTED_PROPERTY_SOURCE_NAME)) {
 						overrides.remove(key);
 					}
 				}


### PR DESCRIPTION
This intends to fix #471, which is a potential regression introduced by both #459 and #462 from what I've seen while debugging. Not really sure if this is the correct approach.

The purpose is to only clean up the `overrides` map from values that have not yet been decrypted. The `decrypted` map is built in the `initialize` method at the very beginning. and is always (I think) the first Map contained by the `propertySourceList`.

Another approach would be a revert of #462 which is actually a micro-optimization that only affects application boot if I understand correctly.
