### PR TITLE
Fix override behaviour when using CompositePropertySource.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -15,7 +15,13 @@
  */
 package org.springframework.cloud.bootstrap.encrypt;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -15,12 +15,7 @@
  */
 package org.springframework.cloud.bootstrap.encrypt;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
@@ -184,9 +179,11 @@ public class EnvironmentDecryptApplicationInitializer implements
 			Map<String, Object> overrides) {
 
 		if (source instanceof CompositePropertySource) {
+			List<PropertySource<?>> propertySources = new ArrayList<>(
+					((CompositePropertySource) source).getPropertySources());
+			Collections.reverse(propertySources);
 
-			for (PropertySource<?> nested : ((CompositePropertySource) source)
-					.getPropertySources()) {
+			for (PropertySource<?> nested : propertySources) {
 				collectEncryptedProperties(nested, overrides);
 			}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.bootstrap.encrypt;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -168,23 +169,31 @@ public class EnvironmentDecryptApplicationInitializerTests {
 
 	@Test
 	public void testDecryptCompositePropertySource() {
-		String expected = "always";
-		TextEncryptor textEncryptor = mock(TextEncryptor.class);
-		when(textEncryptor.decrypt(anyString())).thenReturn(expected);
-
 		ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext();
 		EnvironmentDecryptApplicationInitializer initializer = new EnvironmentDecryptApplicationInitializer(
-				textEncryptor);
+				Encryptors.noOpText());
 
-		MapPropertySource source = new MapPropertySource("nobody",
-				Collections.singletonMap("key", "{cipher}value"));
-		CompositePropertySource cps = mock(CompositePropertySource.class);
-		when(cps.getPropertyNames()).thenReturn(source.getPropertyNames());
-		when(cps.getPropertySources()).thenReturn(Collections.singleton(source));
+		CompositePropertySource cps = new CompositePropertySource("testCPS");
+		Map<String, Object> map1 = new HashMap<>();
+		map1.put("key1", "{cipher}value1b");
+		map1.put("key2", "value2b");
+		cps.addPropertySource(new MapPropertySource("profile1", map1));
+		Map<String, Object> map2 = new HashMap<>();
+		map2.put("key1", "{cipher}value1");
+		map2.put("key2", "value2");
+		map1.put("key3", "value3");
+		cps.addPropertySource(new MapPropertySource("profile2", map2));
+		// add non-enumerable property source that will fail cps.getPropertyNames()
+		cps.addPropertySource(mock(PropertySource.class));
 		ctx.getEnvironment().getPropertySources().addLast(cps);
 
 		initializer.initialize(ctx);
-		assertEquals(expected, ctx.getEnvironment().getProperty("key"));
+		// validate behaviour with encryption
+		assertEquals("value1b", ctx.getEnvironment().getProperty("key1"));
+		// validate behaviour without encryption
+		assertEquals("value2b", ctx.getEnvironment().getProperty("key2"));
+		// validate behaviour without override
+		assertEquals("value3", ctx.getEnvironment().getProperty("key3"));
 	}
 
 	@Test

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -37,7 +37,6 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;


### PR DESCRIPTION
The issue #471 is actually related to https://github.com/spring-cloud/spring-cloud-commons/pull/358 (which just activated an hidden issue). The propertySources from CompositePropertySource should be walked in reversed order for the overrides to behave properly. 

Fixes gh-471