### PR TITLE
Fix overriding encrypted properties

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -167,13 +167,7 @@ public class EnvironmentDecryptApplicationInitializer implements
 
 	public Map<String, Object> decrypt(PropertySources propertySources) {
 		Map<String, Object> overrides = new LinkedHashMap<>();
-		List<PropertySource<?>> sources = new ArrayList<>();
-		for (PropertySource<?> source : propertySources) {
-			sources.add(0, source);
-		}
-		for (PropertySource<?> source : sources) {
-			decrypt(source, overrides);
-		}
+		decryptMultiple(propertySources, overrides);
 		return overrides;
 	}
 
@@ -183,14 +177,22 @@ public class EnvironmentDecryptApplicationInitializer implements
 		return overrides;
 	}
 
+	private void decryptMultiple(Iterable<PropertySource<?>> propertySources,
+								 Map<String, Object> overrides) {
+		List<PropertySource<?>> sources = new ArrayList<>();
+		for (PropertySource<?> source : propertySources) {
+			sources.add(0, source);
+		}
+		for (PropertySource<?> source : sources) {
+			decrypt(source, overrides);
+		}
+	}
+
 	private void decrypt(PropertySource<?> source, Map<String, Object> overrides) {
 
 		if (source instanceof CompositePropertySource) {
-
-			for (PropertySource<?> nested : ((CompositePropertySource) source)
-					.getPropertySources()) {
-				decrypt(nested, overrides);
-			}
+			decryptMultiple(((CompositePropertySource) source).getPropertySources(),
+					overrides);
 
 		}
 		else if (source instanceof EnumerablePropertySource) {

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializerTests.java
@@ -36,11 +36,10 @@ import org.springframework.security.crypto.encrypt.Encryptors;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.cloud.bootstrap.encrypt.EnvironmentDecryptApplicationInitializer.DECRYPTED_PROPERTY_SOURCE_NAME;
 
 /**
@@ -88,7 +87,7 @@ public class EnvironmentDecryptApplicationInitializerTests {
 				.addFirst(new MapPropertySource("test_override",
 						Collections.<String, Object>singletonMap("foo", "spam")));
 		this.listener.initialize(context);
-		assertEquals("spam", context.getEnvironment().getProperty("foo"));
+		then(context.getEnvironment().getProperty("foo")).isEqualTo("spam");
 	}
 
 	@Test
@@ -98,8 +97,8 @@ public class EnvironmentDecryptApplicationInitializerTests {
 		this.listener.initialize(context);
 		TestPropertyValues.of("foo2: {cipher}bar2").applyTo(context);
 		this.listener.initialize(context);
-		assertEquals("bar", context.getEnvironment().getProperty("foo"));
-		assertEquals("bar2", context.getEnvironment().getProperty("foo2"));
+		then(context.getEnvironment().getProperty("foo")).isEqualTo("bar");
+		then(context.getEnvironment().getProperty("foo2")).isEqualTo("bar2");
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -199,11 +198,11 @@ public class EnvironmentDecryptApplicationInitializerTests {
 
 		initializer.initialize(ctx);
 		// validate behaviour with encryption
-		assertEquals("value1b", ctx.getEnvironment().getProperty("key1"));
+		then(ctx.getEnvironment().getProperty("key1")).isEqualTo("value1b");
 		// validate behaviour without encryption
-		assertEquals("value2b", ctx.getEnvironment().getProperty("key2"));
+		then(ctx.getEnvironment().getProperty("key2")).isEqualTo("value2b");
 		// validate behaviour without override
-		assertEquals("value3", ctx.getEnvironment().getProperty("key3"));
+		then(ctx.getEnvironment().getProperty("key3")).isEqualTo("value3");
 	}
 
 	@Test
@@ -218,8 +217,8 @@ public class EnvironmentDecryptApplicationInitializerTests {
 				.addFirst(new MapPropertySource("test_override",
 						Collections.<String, Object>singletonMap("foo", "spam")));
 		initializer.initialize(context);
-		assertEquals("spam", context.getEnvironment().getProperty("foo"));
-		assertEquals("bar2", context.getEnvironment().getProperty("foo2"));
+		then(context.getEnvironment().getProperty("foo")).isEqualTo("spam");
+		then(context.getEnvironment().getProperty("foo2")).isEqualTo("bar2");
 		verify(encryptor).decrypt("bar2");
 		verifyNoMoreInteractions(encryptor);
 	}


### PR DESCRIPTION
This PR contains all the changes from PRs #459, #462 and #473, and includes fixes for #471.
It makes sure that:
1. Encrypted properties can be overridden by not encrypted properties (#459)
1. Properties are only decrypted if they are not overridden. (#462)
1. The property sources from `CompositePropertySource` are, similar to the sources from the environment, looped over in reversed order, so the override behaviour is correct. (#473 / #471)
1. Old decrypted property sources are removed from the environment before decrypting the environment again. (#471)

Besides the projects unit and integration tests, also the test projects from https://github.com/skarzhevskyy/playground-spring-cloud-integration-tests and https://github.com/mpalourdio/ConfigServer / https://github.com/mpalourdio/DiscoveryServer succeed.