### PR TITLE
URL Cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -40,6 +40,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -7,20 +7,20 @@ Edit the files in the src/main/asciidoc/ directory instead.
 image::https://circleci.com/gh/spring-cloud/spring-cloud-commons.svg?style=svg[Build Status, link=https://circleci.com/gh/spring-cloud/spring-cloud-commons]
 
 
-http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook[Cloud Native] is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building http://12factor.net/[12-factor Applications], in which development practices are aligned with delivery and operations goals -- for instance, by using declarative programming and management and monitoring.
+https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook[Cloud Native] is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building https://12factor.net/[12-factor Applications], in which development practices are aligned with delivery and operations goals -- for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.
 
-Many of those features are covered by http://projects.spring.io/spring-boot[Spring Boot], on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+Many of those features are covered by https://projects.spring.io/spring-boot[Spring Boot], on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the `ApplicationContext` of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).
 
 If you get an exception due to "Illegal key size" and you use Sun's JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:
 
-* http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html[Java 6 JCE]
-* http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html[Java 7 JCE]
-* http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java 8 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html[Java 6 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html[Java 7 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java 8 JCE]
 
 Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.
 
@@ -61,7 +61,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -83,13 +83,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -147,7 +147,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -160,7 +160,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -231,7 +231,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -1,10 +1,10 @@
 
-http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook[Cloud Native] is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
-A related discipline is that of building http://12factor.net/[12-factor Applications], in which development practices are aligned with delivery and operations goals -- for instance, by using declarative programming and management and monitoring.
+https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook[Cloud Native] is a style of application development that encourages easy adoption of best practices in the areas of continuous delivery and value-driven development.
+A related discipline is that of building https://12factor.net/[12-factor Applications], in which development practices are aligned with delivery and operations goals -- for instance, by using declarative programming and management and monitoring.
 Spring Cloud facilitates these styles of development in a number of specific ways.
  The starting point is a set of features to which all components in a distributed system need easy access.
 
-Many of those features are covered by http://projects.spring.io/spring-boot[Spring Boot], on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
+Many of those features are covered by https://projects.spring.io/spring-boot[Spring Boot], on which Spring Cloud builds. Some more features are delivered by Spring Cloud as two libraries: Spring Cloud Context and Spring Cloud Commons.
 Spring Cloud Context provides utilities and special services for the `ApplicationContext` of a Spring Cloud application (bootstrap context, encryption, refresh scope, and environment endpoints). Spring Cloud Commons is a set of abstractions and common classes used in different Spring Cloud implementations (such as Spring Cloud Netflix and Spring Cloud Consul).
 
 include::jce.adoc[]

--- a/docs/src/main/asciidoc/jce.adoc
+++ b/docs/src/main/asciidoc/jce.adoc
@@ -1,8 +1,8 @@
 If you get an exception due to "Illegal key size" and you use Sun's JDK, you need to install the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files.
 See the following links for more information:
 
-* http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html[Java 6 JCE]
-* http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html[Java 7 JCE]
-* http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java 8 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html[Java 6 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html[Java 7 JCE]
+* https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html[Java 8 JCE]
 
 Extract the files into the JDK/jre/lib/security folder for whichever version of JRE/JDK x64/x86 you use.

--- a/docs/src/main/asciidoc/spring-cloud-commons.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-commons.adoc
@@ -241,7 +241,7 @@ Patterns such as service discovery, load balancing, and circuit breakers lend th
 Spring Cloud Commons provides the `@EnableDiscoveryClient` annotation.
 This looks for implementations of the `DiscoveryClient` interface with `META-INF/spring.factories`.
 Implementations of the Discovery Client add a configuration class to `spring.factories` under the `org.springframework.cloud.client.discovery.EnableDiscoveryClient` key.
-Examples of `DiscoveryClient` implementations include http://cloud.spring.io/spring-cloud-netflix/[Spring Cloud Netflix Eureka], http://cloud.spring.io/spring-cloud-consul/[Spring Cloud Consul Discovery], and http://cloud.spring.io/spring-cloud-zookeeper/[Spring Cloud Zookeeper Discovery].
+Examples of `DiscoveryClient` implementations include https://cloud.spring.io/spring-cloud-netflix/[Spring Cloud Netflix Eureka], https://cloud.spring.io/spring-cloud-consul/[Spring Cloud Consul Discovery], and https://cloud.spring.io/spring-cloud-zookeeper/[Spring Cloud Zookeeper Discovery].
 
 By default, implementations of `DiscoveryClient` auto-register the local Spring Boot server with the remote discovery server.
 This behavior can be disabled by setting `autoRegister=false` in `@EnableDiscoveryClient`.
@@ -354,7 +354,7 @@ public class MyClass {
     private RestTemplate restTemplate;
 
     public String doOtherStuff() {
-        String results = restTemplate.getForObject("http://stores/stores", String.class);
+        String results = restTemplate.getForObject("https://stores/stores", String.class);
         return results;
     }
 }
@@ -389,7 +389,7 @@ public class MyClass {
     private WebClient.Builder webClientBuilder;
 
     public Mono<String> doOtherStuff() {
-        return webClientBuilder.build().get().uri("http://stores/stores")
+        return webClientBuilder.build().get().uri("https://stores/stores")
         				.retrieve().bodyToMono(String.class);
     }
 }
@@ -496,11 +496,11 @@ public class MyClass {
     private RestTemplate loadBalanced;
 
     public String doOtherStuff() {
-        return loadBalanced.getForObject("http://stores/stores", String.class);
+        return loadBalanced.getForObject("https://stores/stores", String.class);
     }
 
     public String doStuff() {
-        return restTemplate.getForObject("http://example.com", String.class);
+        return restTemplate.getForObject("https://example.com", String.class);
     }
 }
 ----
@@ -521,7 +521,7 @@ public class MyClass {
     private LoadBalancerExchangeFilterFunction lbFunction;
 
     public Mono<String> doOtherStuff() {
-        return WebClient.builder().baseUrl("http://stores")
+        return WebClient.builder().baseUrl("https://stores")
             .filter(lbFunction)
             .build()
             .get()

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/EnableCircuitBreaker.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/EnableCircuitBreaker.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Import;
 
 /**
  * Annotation to enable a CircuitBreaker implementation.
- * http://martinfowler.com/bliki/CircuitBreaker.html
+ * https://martinfowler.com/bliki/CircuitBreaker.html
  * @author Spencer Gibb
  */
 @Target(ElementType.TYPE)

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerClient.java
@@ -59,7 +59,7 @@ public interface LoadBalancerClient extends ServiceInstanceChooser {
 	/**
 	 * Creates a proper URI with a real host and port for systems to utilize. Some systems
 	 * use a URI with the logical service name as the host, such as
-	 * http://myservice/path/to/service. This will replace the service name with the
+	 * https://myservice/path/to/service. This will replace the service name with the
 	 * host:port from the ServiceInstance.
 	 * @param instance service instance to reconstruct the URI
 	 * @param original A URI with the host as a logical service name.

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientTests.java
@@ -38,7 +38,7 @@ import static org.springframework.cloud.client.discovery.composite.CompositeDisc
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "spring.application.name=service0",
-		"spring.cloud.discovery.client.simple.instances.service1[0].uri=http://s1-1:8080",
+		"spring.cloud.discovery.client.simple.instances.service1[0].uri=https://s1-1:8080",
 		"spring.cloud.discovery.client.simple.instances.service1[1].uri=https://s1-2:8443",
 		"spring.cloud.discovery.client.simple.instances.service2[0].uri=https://s2-1:8080",
 		"spring.cloud.discovery.client.simple.instances.service2[1].uri=https://s2-2:443" }, classes = {
@@ -57,7 +57,7 @@ public class CompositeDiscoveryClientTests {
 		ServiceInstance s1 = this.discoveryClient.getInstances("service1").get(0);
 		then(s1.getHost()).isEqualTo("s1-1");
 		then(s1.getPort()).isEqualTo(8080);
-		then(s1.getUri()).isEqualTo(URI.create("http://s1-1:8080"));
+		then(s1.getUri()).isEqualTo(URI.create("https://s1-1:8080"));
 		then(s1.isSecure()).isEqualTo(false);
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientPropertiesMappingTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientPropertiesMappingTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "spring.application.name=service0",
-		"spring.cloud.discovery.client.simple.instances.service1[0].uri=http://s1-1:8080",
+		"spring.cloud.discovery.client.simple.instances.service1[0].uri=https://s1-1:8080",
 		"spring.cloud.discovery.client.simple.instances.service1[1].uri=https://s1-2:8443",
 		"spring.cloud.discovery.client.simple.instances.service2[0].uri=https://s2-1:8080",
 		"spring.cloud.discovery.client.simple.instances.service2[1].uri=https://s2-2:443" })
@@ -58,7 +58,7 @@ public class SimpleDiscoveryClientPropertiesMappingTests {
 				.isEqualTo("s1-1");
 		then(this.props.getInstances().get("service1").get(0).getPort()).isEqualTo(8080);
 		then(this.props.getInstances().get("service1").get(0).getUri())
-				.isEqualTo(URI.create("http://s1-1:8080"));
+				.isEqualTo(URI.create("https://s1-1:8080"));
 		then(this.props.getInstances().get("service1").get(0).isSecure())
 				.isEqualTo(false);
 
@@ -79,7 +79,7 @@ public class SimpleDiscoveryClientPropertiesMappingTests {
 		ServiceInstance s1 = this.discoveryClient.getInstances("service1").get(0);
 		then(s1.getHost()).isEqualTo("s1-1");
 		then(s1.getPort()).isEqualTo(8080);
-		then(s1.getUri()).isEqualTo(URI.create("http://s1-1:8080"));
+		then(s1.getUri()).isEqualTo(URI.create("https://s1-1:8080"));
 		then(s1.isSecure()).isEqualTo(false);
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
@@ -43,7 +43,7 @@ public class SimpleDiscoveryClientTests {
 
 		Map<String, List<SimpleServiceInstance>> map = new HashMap<>();
 		SimpleServiceInstance service1Inst1 = new SimpleServiceInstance(
-				URI.create("http://host1:8080"));
+				URI.create("https://host1:8080"));
 		SimpleServiceInstance service1Inst2 = new SimpleServiceInstance(
 				URI.create("https://host2:8443"));
 		map.put("service1", Arrays.asList(service1Inst1, service1Inst2));
@@ -60,7 +60,7 @@ public class SimpleDiscoveryClientTests {
 		then(instances.get(0).getServiceId()).isEqualTo("service1");
 		then(instances.get(0).getHost()).isEqualTo("host1");
 		then(instances.get(0).getPort()).isEqualTo(8080);
-		then(instances.get(0).getUri()).isEqualTo(URI.create("http://host1:8080"));
+		then(instances.get(0).getUri()).isEqualTo(URI.create("https://host1:8080"));
 		then(instances.get(0).isSecure()).isEqualTo(false);
 		then(instances.get(0).getMetadata()).isNotNull();
 	}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/RetryLoadBalancerInterceptorTest.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/RetryLoadBalancerInterceptorTest.java
@@ -86,7 +86,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test(expected = IOException.class)
 	public void interceptDisableRetry() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		ServiceInstance serviceInstance = mock(ServiceInstance.class);
 		when(this.client.choose(eq("foo"))).thenReturn(serviceInstance);
 		when(this.client.execute(eq("foo"), eq(serviceInstance),
@@ -108,7 +108,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test(expected = IllegalStateException.class)
 	public void interceptInvalidHost() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo_underscore"));
+		when(request.getURI()).thenReturn(new URI("https://foo_underscore"));
 		this.lbProperties.setEnabled(true);
 		RetryLoadBalancerInterceptor interceptor = new RetryLoadBalancerInterceptor(
 				this.client, this.lbProperties, this.lbRequestFactory,
@@ -121,7 +121,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void interceptNeverRetry() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		ServiceInstance serviceInstance = mock(ServiceInstance.class);
@@ -143,7 +143,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void interceptSuccess() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);
@@ -167,7 +167,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void interceptRetryOnStatusCode() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		InputStream notFoundStream = mock(InputStream.class);
 		when(notFoundStream.read(any(byte[].class))).thenReturn(-1);
 		ClientHttpResponse clientHttpResponseNotFound = new MockClientHttpResponse(
@@ -202,7 +202,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void interceptRetryFailOnStatusCode() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 
 		InputStream notFoundStream = new ByteArrayInputStream("foo".getBytes());
 		ClientHttpResponse clientHttpResponseNotFound = new MockClientHttpResponse(
@@ -243,7 +243,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void interceptRetry() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);
@@ -274,7 +274,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test(expected = IOException.class)
 	public void interceptFailedRetry() throws Exception {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://foo"));
+		when(request.getURI()).thenReturn(new URI("https://foo"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);
@@ -300,7 +300,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void retryListenerTest() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://listener"));
+		when(request.getURI()).thenReturn(new URI("https://listener"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);
@@ -334,7 +334,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test(expected = TerminatedRetryException.class)
 	public void retryListenerTestNoRetry() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://noRetry"));
+		when(request.getURI()).thenReturn(new URI("https://noRetry"));
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);
 		MyBackOffPolicy backOffPolicy = new MyBackOffPolicy();
 		this.lbProperties.setEnabled(true);
@@ -356,7 +356,7 @@ public class RetryLoadBalancerInterceptorTest {
 	@Test
 	public void retryWithDefaultConstructorTest() throws Throwable {
 		HttpRequest request = mock(HttpRequest.class);
-		when(request.getURI()).thenReturn(new URI("http://default"));
+		when(request.getURI()).thenReturn(new URI("https://default"));
 		ClientHttpResponse clientHttpResponse = new MockClientHttpResponse(new byte[] {},
 				HttpStatus.OK);
 		LoadBalancedRetryPolicy policy = mock(LoadBalancedRetryPolicy.class);

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerExchangeFilterFunctionTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerExchangeFilterFunctionTests.java
@@ -85,14 +85,14 @@ public class LoadBalancerExchangeFilterFunctionTests {
 
 	@Test
 	public void testNoInstance() {
-		ClientResponse clientResponse = WebClient.builder().baseUrl("http://foobar")
+		ClientResponse clientResponse = WebClient.builder().baseUrl("https://foobar")
 				.filter(this.lbFunction).build().get().exchange().block();
 		then(clientResponse.statusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 	}
 
 	@Test
 	public void testNoHostName() {
-		ClientResponse clientResponse = WebClient.builder().baseUrl("http:///foobar")
+		ClientResponse clientResponse = WebClient.builder().baseUrl("https:///foobar")
 				.filter(this.lbFunction).build().get().exchange().block();
 		then(clientResponse.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 	}

--- a/spring-cloud-loadbalancer/src/test/resources/application.yml
+++ b/spring-cloud-loadbalancer/src/test/resources/application.yml
@@ -6,22 +6,22 @@ spring:
           instances:
             myservice:
               - service-id: myservice
-                uri: http://a.host
+                uri: https://a.host
               - service-id: myservice
-                uri: http://c.host
+                uri: https://c.host
               - service-id: myservice
                 uri: https://b.host-secure
             anotherservice:
               - service-id: myservice
-                uri: http://d.host
+                uri: https://d.host
               - service-id: myservice
-                uri: http://f.host
+                uri: https://f.host
               - service-id: myservice
                 uri: https://e.host
             thirdservice:
               - service-id: myservice
-                uri: http://g.host
+                uri: https://g.host
               - service-id: myservice
-                uri: http://h.host
+                uri: https://h.host
               - service-id: myservice
                 uri: https://i.host


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http:///foobar (UnknownHostException) with 1 occurrences migrated to:  
  https:///foobar ([https](https:///foobar) result UnknownHostException).
* [ ] http://a.host (UnknownHostException) with 1 occurrences migrated to:  
  https://a.host ([https](https://a.host) result UnknownHostException).
* [ ] http://c.host (UnknownHostException) with 1 occurrences migrated to:  
  https://c.host ([https](https://c.host) result UnknownHostException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://d.host (UnknownHostException) with 1 occurrences migrated to:  
  https://d.host ([https](https://d.host) result UnknownHostException).
* [ ] http://default (UnknownHostException) with 1 occurrences migrated to:  
  https://default ([https](https://default) result UnknownHostException).
* [ ] http://f.host (UnknownHostException) with 1 occurrences migrated to:  
  https://f.host ([https](https://f.host) result UnknownHostException).
* [ ] http://foo (UnknownHostException) with 7 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).
* [ ] http://foo_underscore (UnknownHostException) with 1 occurrences migrated to:  
  https://foo_underscore ([https](https://foo_underscore) result UnknownHostException).
* [ ] http://foobar (UnknownHostException) with 1 occurrences migrated to:  
  https://foobar ([https](https://foobar) result UnknownHostException).
* [ ] http://g.host (UnknownHostException) with 1 occurrences migrated to:  
  https://g.host ([https](https://g.host) result UnknownHostException).
* [ ] http://h.host (UnknownHostException) with 1 occurrences migrated to:  
  https://h.host ([https](https://h.host) result UnknownHostException).
* [ ] http://host1:8080 (UnknownHostException) with 2 occurrences migrated to:  
  https://host1:8080 ([https](https://host1:8080) result UnknownHostException).
* [ ] http://listener (UnknownHostException) with 1 occurrences migrated to:  
  https://listener ([https](https://listener) result UnknownHostException).
* [ ] http://myservice/path/to/service (UnknownHostException) with 1 occurrences migrated to:  
  https://myservice/path/to/service ([https](https://myservice/path/to/service) result UnknownHostException).
* [ ] http://noRetry (UnknownHostException) with 1 occurrences migrated to:  
  https://noRetry ([https](https://noRetry) result UnknownHostException).
* [ ] http://s1-1:8080 (UnknownHostException) with 5 occurrences migrated to:  
  https://s1-1:8080 ([https](https://s1-1:8080) result UnknownHostException).
* [ ] http://stores (UnknownHostException) with 1 occurrences migrated to:  
  https://stores ([https](https://stores) result UnknownHostException).
* [ ] http://stores/stores (UnknownHostException) with 3 occurrences migrated to:  
  https://stores/stores ([https](https://stores/stores) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://12factor.net/ with 2 occurrences migrated to:  
  https://12factor.net/ ([https](https://12factor.net/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-consul/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-consul/ ([https](https://cloud.spring.io/spring-cloud-consul/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-zookeeper/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-zookeeper/ ([https](https://cloud.spring.io/spring-cloud-zookeeper/) result 200).
* [ ] http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://martinfowler.com/bliki/CircuitBreaker.html with 1 occurrences migrated to:  
  https://martinfowler.com/bliki/CircuitBreaker.html ([https](https://martinfowler.com/bliki/CircuitBreaker.html) result 200).
* [ ] http://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook with 2 occurrences migrated to:  
  https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook ([https](https://pivotal.io/platform-as-a-service/migrating-to-cloud-native-application-architectures-ebook) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html with 2 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html with 2 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html with 2 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projects.spring.io/spring-boot with 2 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 4 occurrences
* http://localhost:8888 with 1 occurrences
* http://testservice with 1 occurrences