### PR TITLE
Detect dynamic mgmt port. Fixes gh-561

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -25,15 +25,17 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
-import org.springframework.boot.web.context.ConfigurableWebServerApplicationContext;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;
 import org.springframework.cloud.client.discovery.event.InstancePreRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 /**
  * Lifecycle methods that may be useful and common to {@link ServiceRegistry}
@@ -43,10 +45,11 @@ import org.springframework.core.env.Environment;
  *
  * @param <R> Registration type passed to the {@link ServiceRegistry}.
  * @author Spencer Gibb
+ * @author Chris White
  */
 public abstract class AbstractAutoServiceRegistration<R extends Registration>
 		implements AutoServiceRegistration, ApplicationContextAware,
-		ApplicationListener<WebServerInitializedEvent> {
+		ApplicationListener<ApplicationEvent> {
 
 	private static final Log logger = LogFactory
 			.getLog(AbstractAutoServiceRegistration.class);
@@ -64,6 +67,8 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 	private Environment environment;
 
 	private AtomicInteger port = new AtomicInteger(0);
+
+	private AtomicInteger mgmtPort = new AtomicInteger(0);
 
 	private AutoServiceRegistrationProperties properties;
 
@@ -83,22 +88,25 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
-	public void onApplicationEvent(WebServerInitializedEvent event) {
-		bind(event);
+	public void onApplicationEvent(ApplicationEvent event) {
+		if (event instanceof ApplicationReadyEvent) {
+			this.start();
+		}
+		else if (event instanceof WebServerInitializedEvent) {
+			this.bind((WebServerInitializedEvent) event);
+		}
 	}
 
 	@Deprecated
 	public void bind(WebServerInitializedEvent event) {
-		ApplicationContext context = event.getApplicationContext();
-		if (context instanceof ConfigurableWebServerApplicationContext) {
-			if ("management".equals(((ConfigurableWebServerApplicationContext) context)
-					.getServerNamespace())) {
-				return;
-			}
+		String serverNamespace = event.getApplicationContext().getServerNamespace();
+
+		if (StringUtils.isEmpty(serverNamespace)) {
+			this.port.compareAndSet(0, event.getWebServer().getPort());
 		}
-		this.port.compareAndSet(0, event.getWebServer().getPort());
-		this.start();
+		else if ("management".equals(serverNamespace)) {
+			this.mgmtPort.compareAndSet(0, event.getWebServer().getPort());
+		}
 	}
 
 	@Override
@@ -192,7 +200,12 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 	 */
 	@Deprecated
 	protected Integer getManagementPort() {
-		return ManagementServerPortUtils.getPort(this.context);
+		if (this.mgmtPort.get() != 0) {
+			return this.mgmtPort.get();
+		}
+		else {
+			return ManagementServerPortUtils.getPort(this.context);
+		}
 	}
 
 	/**

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationMgmtDisabledTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationMgmtDisabledTests.java
@@ -38,9 +38,10 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * @author Tim Ysewyn
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = AbstractAutoServiceRegistrationMgmtDisabledTests.Config.class, properties = {
-		"management.port=0",
-		"spring.cloud.service-registry.auto-registration.register-management=false" }, webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = AbstractAutoServiceRegistrationMgmtDisabledTests.Config.class,
+		properties = { "management.server.port=0",
+				"spring.cloud.service-registry.auto-registration.register-management=false" },
+		webEnvironment = RANDOM_PORT)
 public class AbstractAutoServiceRegistrationMgmtDisabledTests {
 
 	@Autowired

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationTests.java
@@ -44,7 +44,8 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 // @checkstyle:off
-@SpringBootTest(classes = AbstractAutoServiceRegistrationTests.Config.class, properties = "management.port=0", webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = AbstractAutoServiceRegistrationTests.Config.class,
+		properties = "management.server.port=0", webEnvironment = RANDOM_PORT)
 // @checkstyle:on
 public class AbstractAutoServiceRegistrationTests {
 


### PR DESCRIPTION
Ignoring the checkstyle auto-fixed whitespace changes, see:
* spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java - Capture management web server init event & wait for ApplicationReadyEvent before starting registration (to ensure that http & optional mgmt ports have been discovered)
* spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationMgmtDisabledTests.java - updated correct property for mgmt port
* spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationTests.java - updated correct property for mgmt port