### PR TITLE
refactor(spring-cloud-commons): Change the Event listened by Abstract…

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -25,8 +25,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.context.ConfigurableWebServerApplicationContext;
-import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;
 import org.springframework.cloud.client.discovery.event.InstancePreRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
@@ -46,7 +46,7 @@ import org.springframework.core.env.Environment;
  */
 public abstract class AbstractAutoServiceRegistration<R extends Registration>
 		implements AutoServiceRegistration, ApplicationContextAware,
-		ApplicationListener<WebServerInitializedEvent> {
+		ApplicationListener<ApplicationReadyEvent> {
 
 	private static final Log logger = LogFactory
 			.getLog(AbstractAutoServiceRegistration.class);
@@ -84,12 +84,12 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void onApplicationEvent(WebServerInitializedEvent event) {
+	public void onApplicationEvent(ApplicationReadyEvent event) {
 		bind(event);
 	}
 
 	@Deprecated
-	public void bind(WebServerInitializedEvent event) {
+	public void bind(ApplicationReadyEvent event) {
 		ApplicationContext context = event.getApplicationContext();
 		if (context instanceof ConfigurableWebServerApplicationContext) {
 			if ("management".equals(((ConfigurableWebServerApplicationContext) context)
@@ -97,7 +97,8 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 				return;
 			}
 		}
-		this.port.compareAndSet(0, event.getWebServer().getPort());
+		String port = context.getEnvironment().getProperty("server.port");
+		this.port.compareAndSet(0, Integer.valueOf(port));
 		this.start();
 	}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.context.ConfigurableWebServerApplicationContext;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;
@@ -34,6 +35,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.Assert;
 
 /**
  * Lifecycle methods that may be useful and common to {@link ServiceRegistry}
@@ -47,6 +50,7 @@ import org.springframework.core.env.Environment;
 public abstract class AbstractAutoServiceRegistration<R extends Registration>
 		implements AutoServiceRegistration, ApplicationContextAware,
 		ApplicationListener<ApplicationReadyEvent> {
+
 
 	private static final Log logger = LogFactory
 			.getLog(AbstractAutoServiceRegistration.class);
@@ -98,6 +102,9 @@ public abstract class AbstractAutoServiceRegistration<R extends Registration>
 			}
 		}
 		String port = context.getEnvironment().getProperty("server.port");
+		if (environment instanceof StandardEnvironment) {
+			Assert.isNull(port, "If spring main web application type none is set, the server port must be declared");
+		}
 		this.port.compareAndSet(0, Integer.valueOf(port));
 		this.start();
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistration.java
@@ -25,7 +25,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.context.ConfigurableWebServerApplicationContext;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;


### PR DESCRIPTION
…AutoServiceRegistration to Appl

Some services built by springboot have spring.main.web-application-type=none case, which will cause
the service to not be automatically registered.