### PR TITLE
Extend ServiceInstanceChooser with new choose method

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/ServiceInstanceChooser.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/ServiceInstanceChooser.java
@@ -33,4 +33,14 @@ public interface ServiceInstanceChooser {
 	 */
 	ServiceInstance choose(String serviceId);
 
+	/**
+	 * Chooses a ServiceInstance from the LoadBalancer for the specified service and according to the specified hint.
+	 * @param serviceId The service ID to look up the LoadBalancer.
+	 * @param hint to specify the service instance
+	 * @return A ServiceInstance that matches the serviceId.
+	 */
+	default ServiceInstance choose(String serviceId, Object hint) {
+		return choose(serviceId);
+	}
+
 }

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerExchangeFilterFunctionTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerExchangeFilterFunctionTests.java
@@ -141,6 +141,7 @@ public class LoadBalancerExchangeFilterFunctionTests {
 					int instanceIdx = this.random.nextInt(instances.size());
 					return instances.get(instanceIdx);
 				}
+
 			};
 		}
 


### PR DESCRIPTION
In case you need to choose instance based on some additional parameters there is no way to do that using `ServiceInstanceChooser`. It currently only gives ability to choose instance based only on service name.
`ServiceInstanceChooser` is implemented by `RibbonLoadBalancerClient` and already has this method `ServiceInstance choose(String serviceId, Object hint)` that is not exposed in the interface.