### PR TITLE
Changed order of decrypting values.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EnvironmentDecryptApplicationInitializer.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.bootstrap.encrypt;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -187,8 +188,11 @@ public class EnvironmentDecryptApplicationInitializer implements
 
 		if (source instanceof CompositePropertySource) {
 
-			for (PropertySource<?> nested : ((CompositePropertySource) source)
-					.getPropertySources()) {
+			List<PropertySource<?>> sources = new ArrayList<>(
+					((CompositePropertySource) source).getPropertySources());
+			Collections.reverse(sources);
+
+			for (PropertySource<?> nested : sources) {
 				decrypt(nested, overrides);
 			}
 


### PR DESCRIPTION
Reversed order of sources in `CompositePropertySource` to adhere to the order of sources returned by the Spring Cloud Config server.
Fixes #574 