### PR TITLE
Adds OriginTrackedCompositePropertySource for bootstrap

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
@@ -37,7 +37,10 @@ import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEven
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.env.OriginTrackedMapPropertySource;
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.origin.OriginLookup;
 import org.springframework.cloud.bootstrap.encrypt.EnvironmentDecryptApplicationInitializer;
+import org.springframework.cloud.bootstrap.support.OriginTrackedCompositePropertySource;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -416,15 +419,15 @@ public class BootstrapApplicationListener
 	}
 
 	private static class ExtendedDefaultPropertySource
-			extends SystemEnvironmentPropertySource {
+			extends SystemEnvironmentPropertySource implements OriginLookup<String> {
 
-		private final CompositePropertySource sources;
+		private final OriginTrackedCompositePropertySource sources;
 
 		private final List<String> names = new ArrayList<>();
 
 		ExtendedDefaultPropertySource(String name, PropertySource<?> propertySource) {
 			super(name, findMap(propertySource));
-			this.sources = new CompositePropertySource(name);
+			this.sources = new OriginTrackedCompositePropertySource(name);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -474,6 +477,11 @@ public class BootstrapApplicationListener
 			names.addAll(Arrays.asList(this.sources.getPropertyNames()));
 			names.addAll(Arrays.asList(super.getPropertyNames()));
 			return names.toArray(new String[0]);
+		}
+
+		@Override
+		public Origin getOrigin(String name) {
+			return this.sources.getOrigin(name);
 		}
 
 	}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.boot.logging.LogFile;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
+import org.springframework.cloud.bootstrap.support.OriginTrackedCompositePropertySource;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.logging.LoggingRebinder;
 import org.springframework.context.ApplicationContextInitializer;
@@ -87,7 +88,7 @@ public class PropertySourceBootstrapConfiguration implements
 
 	@Override
 	public void initialize(ConfigurableApplicationContext applicationContext) {
-		CompositePropertySource composite = new CompositePropertySource(
+		CompositePropertySource composite = new OriginTrackedCompositePropertySource(
 				BOOTSTRAP_PROPERTY_SOURCE_NAME);
 		AnnotationAwareOrderComparator.sort(this.propertySourceLocators);
 		boolean empty = true;

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/support/OriginTrackedCompositePropertySource.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/support/OriginTrackedCompositePropertySource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.bootstrap.support;
+
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.origin.OriginLookup;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.PropertySource;
+
+public class OriginTrackedCompositePropertySource extends CompositePropertySource
+		implements OriginLookup<String> {
+
+	/**
+	 * Create a new {@code CompositePropertySource}.
+	 * @param name the name of the property source
+	 */
+	public OriginTrackedCompositePropertySource(String name) {
+		super(name);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Origin getOrigin(String name) {
+		for (PropertySource<?> propertySource : getPropertySources()) {
+			if (propertySource instanceof OriginLookup) {
+				OriginLookup lookup = (OriginLookup) propertySource;
+				Origin origin = lookup.getOrigin(name);
+				if (origin != null) {
+					return origin;
+				}
+			}
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
This allows the boot origin tracking mechanism to work if bootstrap loaded propertysources themselves are also origin tracked.

See https://github.com/spring-cloud/spring-cloud-config/issues/866