### PR TITLE
Add once method for Customizer of circuit breaker

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
@@ -86,3 +86,19 @@ the links below
 * link:../../../spring-cloud-circuitbreaker/reference/html/spring-cloud-circuitbreaker.html#_configuring_resilience4j_circuit_breakers[Resilience4J]
 * link:../../../spring-cloud-circuitbreaker/reference/html/spring-cloud-circuitbreaker.html#_configuring_sentinel_circuit_breakers[Sentinal]
 * link:../../../spring-cloud-circuitbreaker/reference/html/spring-cloud-circuitbreaker.html#_configuring_spring_retry_circuit_breakers[Spring Retry]
+
+Some `CircuitBreaker` implementations such as `Resilience4JCircuitBreaker` calls `customize` method every time `CircuitBreaker#run` is called.
+It can be inefficient. In that case, you can use `CircuitBreaker#once` method. It is useful where calling `customize` many times doesn't make sense,
+for example, in case of https://resilience4j.readme.io/docs/circuitbreaker#section-consume-emitted-circuitbreakerevents[consuming Resilience4j's  events].
+
+The following example shows the way for each `io.github.resilience4j.circuitbreaker.CircuitBreaker` to consume events.
+
+====
+[source,java]
+----
+Customizer.once(circuitBreaker -> {
+  circuitBreaker.getEventPublisher()
+    .onStateTransition(event -> log.info("{}: {}", event.getCircuitBreakerName(), event.getStateTransition()));
+}, CircuitBreaker::getName)
+----
+====

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/Customizer.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/Customizer.java
@@ -16,13 +16,40 @@
 
 package org.springframework.cloud.client.circuitbreaker;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
 /**
  * Customizes the parameterized class.
  *
  * @author Ryan Baxter
+ * @author Toshiaki Maki
  */
 public interface Customizer<TOCUSTOMIZE> {
 
 	void customize(TOCUSTOMIZE tocustomize);
+
+	/**
+	 * Create a wrapped customizer that guarantees that the {@link #customize(Object)}
+	 * method of the delegated <code>customizer</code> is called at most once per target.
+	 * @param customizer a customizer to be delegated
+	 * @param keyMapper a mapping function to produce the identifier of the target
+	 * @param <T> the type of the target to customize
+	 * @param <K> the type of the identifier of the target
+	 * @return a wrapped customizer
+	 */
+	static <T, K> Customizer<T> once(Customizer<T> customizer,
+			Function<? super T, ? extends K> keyMapper) {
+		final Set<K> customized = Collections.newSetFromMap(new ConcurrentHashMap<>());
+		return t -> {
+			final K key = keyMapper.apply(t);
+			if (!customized.contains(key)) {
+				customized.add(key);
+				customizer.customize(t);
+			}
+		};
+	}
 
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/Customizer.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/Customizer.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.client.circuitbreaker;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 /**
@@ -42,13 +41,13 @@ public interface Customizer<TOCUSTOMIZE> {
 	 */
 	static <T, K> Customizer<T> once(Customizer<T> customizer,
 			Function<? super T, ? extends K> keyMapper) {
-		final Set<K> customized = Collections.newSetFromMap(new ConcurrentHashMap<>());
+		final ConcurrentMap<K, Boolean> customized = new ConcurrentHashMap<>();
 		return t -> {
 			final K key = keyMapper.apply(t);
-			if (!customized.contains(key)) {
-				customized.add(key);
+			customized.computeIfAbsent(key, k -> {
 				customizer.customize(t);
-			}
+				return true;
+			});
 		};
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/circuitbreaker/CustomizerTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/circuitbreaker/CustomizerTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.client.circuitbreaker;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class CustomizerTests {
+
+	@Test
+	public void testCustomizedOnlyOnce() {
+		AtomicInteger counter = new AtomicInteger(0);
+		final Customizer<AtomicInteger> customizer = Customizer
+				.once(AtomicInteger::incrementAndGet, Object::hashCode);
+		customizer.customize(counter);
+		customizer.customize(counter);
+		customizer.customize(counter);
+		Assertions.assertThat(counter.get()).isEqualTo(1);
+
+		AtomicInteger anotherCounter = new AtomicInteger(0);
+		customizer.customize(anotherCounter);
+		customizer.customize(anotherCounter);
+		Assertions.assertThat(counter.get()).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
This PR adds `once` method to `org.springframework.cloud.client.circuitbreaker.Customizer` that guarantees `customize` method is called at most once per target.

Some `CircuitBreaker` implementations such as `Resilience4JCircuitBreaker` calls `customize` method every time `CircuitBreaker#run` is called.  It is sometimes inefficient and troublesome.
Using `once` method is useful where calling `customize` many times doesn't make sense,
for example, in case of [consuming Resilience4j's  events](https://resilience4j.readme.io/docs/circuitbreaker#section-consume-emitted-circuitbreakerevents).

Here is an example for each `io.github.resilience4j.circuitbreaker.CircuitBreaker` to consume events. 

```java
Customizer.once(circuitBreaker -> {
  circuitBreaker.getEventPublisher()
    .onStateTransition(event -> log.info("{}: {}", event.getCircuitBreakerName(), event.getStateTransition()));
}, CircuitBreaker::getName)
```