### PR TITLE
Fixes issues in HealthCheckServiceInstanceListSupplier

### DIFF
--- a/spring-cloud-loadbalancer/pom.xml
+++ b/spring-cloud-loadbalancer/pom.xml
@@ -88,5 +88,10 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.loadbalancer.core;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -69,10 +70,10 @@ public class HealthCheckServiceInstanceListSupplier
 		this.defaultHealthCheckPath = healthCheck.getPath().getOrDefault("default",
 				"/actuator/health");
 		this.webClient = webClient;
-		this.aliveInstancesReplay = delegate.get()
+		this.aliveInstancesReplay = Flux.defer(delegate)
 				.delaySubscription(Duration.ofMillis(this.healthCheck.getInitialDelay()))
 				.switchMap(serviceInstances -> healthCheckFlux(serviceInstances)
-						.map(alive -> (List<ServiceInstance>) new ArrayList<>(alive))
+						.map(alive -> Collections.unmodifiableList(new ArrayList<>(alive)))
 				)
 				.replay(1)
 				.refCount(1);

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -125,8 +125,8 @@ public class HealthCheckServiceInstanceListSupplier
 			})
 			.defaultIfEmpty(result);
 		})
-		.repeatWhen(restart -> restart.delayElements(healthCheck.getInterval()))
-		.delaySubscription(Duration.ofMillis(healthCheck.getInitialDelay()));
+		.repeatWhen(restart -> restart.delayElements(this.healthCheck.getInterval()))
+		.delaySubscription(Duration.ofMillis(this.healthCheck.getInitialDelay()));
 	}
 
 	@Override

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -58,9 +58,9 @@ public class HealthCheckServiceInstanceListSupplier
 
 	private final String defaultHealthCheckPath;
 
-	private Disposable healthCheckDisposable;
+	private final Flux<List<ServiceInstance>> aliveInstancesReplay;
 
-	private Flux<List<ServiceInstance>> aliveInstancesReplay;
+	private Disposable healthCheckDisposable;
 
 	public HealthCheckServiceInstanceListSupplier(ServiceInstanceListSupplier delegate,
 			LoadBalancerProperties.HealthCheck healthCheck, WebClient webClient) {
@@ -75,8 +75,7 @@ public class HealthCheckServiceInstanceListSupplier
 						.map(alive -> (List<ServiceInstance>) new ArrayList<>(alive))
 				)
 				.replay(1)
-				.refCount(1)
-				.onBackpressureLatest();
+				.refCount(1);
 	}
 
 	@Override

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -117,7 +116,7 @@ public class HealthCheckServiceInstanceListSupplier
 
 				checks.add(alive);
 			}
-			List<ServiceInstance> result = new CopyOnWriteArrayList<>();
+			List<ServiceInstance> result = new ArrayList<>();
 			return Flux.merge(checks).map(alive -> {
 				result.add(alive);
 				return result;

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -79,8 +79,9 @@ public class HealthCheckServiceInstanceListSupplier
 	private void initInstances() {
 		healthCheckDisposable = delegate.get().doOnNext(delegateInstances -> {
 			instances = Collections.unmodifiableList(new ArrayList<>(delegateInstances));
-		}).thenMany(healthCheckFlux()).subscribeOn(Schedulers.parallel())
-				.subscribe(verifiedInstances -> healthyInstances = verifiedInstances);
+		})
+		.thenMany(healthCheckFlux()).subscribeOn(Schedulers.parallel())
+		.subscribe(verifiedInstances -> healthyInstances = verifiedInstances);
 	}
 
 	protected Flux<List<ServiceInstance>> healthCheckFlux() {
@@ -100,8 +101,9 @@ public class HealthCheckServiceInstanceListSupplier
 				result.add(alive);
 				return result;
 			}).defaultIfEmpty(result);
-		}).repeatWhen(restart -> restart.delayElements(healthCheck.getInterval()))
-				.delaySubscription(Duration.ofMillis(healthCheck.getInitialDelay()));
+		})
+		.repeatWhen(restart -> restart.delayElements(healthCheck.getInterval()))
+		.delaySubscription(Duration.ofMillis(healthCheck.getInitialDelay()));
 	}
 
 	@Override
@@ -115,8 +117,7 @@ public class HealthCheckServiceInstanceListSupplier
 			List<ServiceInstance> it = new ArrayList<>(healthyInstances);
 			if (it.isEmpty()) {
 				if (LOG.isWarnEnabled()) {
-					LOG.warn(
-							"No verified healthy instances were found, returning all listed instances.");
+					LOG.warn("No verified healthy instances were found, returning all listed instances.");
 				}
 				it = instances;
 			}
@@ -132,8 +133,10 @@ public class HealthCheckServiceInstanceListSupplier
 		return webClient.get()
 				.uri(UriComponentsBuilder.fromUri(serviceInstance.getUri())
 						.path(healthCheckPath).build().toUri())
-				.exchange().flatMap(clientResponse -> clientResponse.releaseBody()
-						.thenReturn(HttpStatus.OK.equals(clientResponse.statusCode())));
+				.exchange()
+				.flatMap(clientResponse -> clientResponse.releaseBody()
+						.thenReturn(HttpStatus.OK.equals(clientResponse.statusCode()))
+				);
 	}
 
 	@Override

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
@@ -167,7 +167,8 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNoEvent(Duration.ofMillis(healthCheck.getInitialDelay()))
 				.expectNext(Lists.list(si1))
 				.expectNoEvent(healthCheck.getInterval())
-				.thenCancel().verify(VERIFY_TIMEOUT);
+				.thenCancel()
+				.verify(VERIFY_TIMEOUT);
 	}
 
 	@Test
@@ -307,8 +308,10 @@ class HealthCheckServiceInstanceListSupplierTests {
 		})
 				.expectSubscription()
 				.expectNoEvent(Duration.ofMillis(healthCheck.getInitialDelay()))
-				.expectNext(Lists.list(si1)).expectNoEvent(healthCheck.getInterval())
-				.thenCancel().verify(VERIFY_TIMEOUT);
+				.expectNext(Lists.list(si1))
+				.expectNoEvent(healthCheck.getInterval())
+				.thenCancel()
+				.verify(VERIFY_TIMEOUT);
 	}
 
 	@Test

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
@@ -140,7 +140,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNext(Lists.list(si1))
 				.expectNoEvent(healthCheck.getInterval())
 				.thenCancel()
-				.verify();
+				.verify(healthCheck.getInterval().multipliedBy(4));
 	}
 
 	@Test
@@ -167,7 +167,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNext(Lists.list(si1, si2))
 				.expectNoEvent(healthCheck.getInterval())
 				.thenCancel()
-				.verify();
+				.verify(healthCheck.getInterval().multipliedBy(4));
 	}
 
 	@Test
@@ -192,7 +192,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNext(Lists.list(si1))
 				.expectNoEvent(Duration.ofMillis(healthCheck.getInitialDelay()).plus(healthCheck.getInterval()))
 				.thenCancel()
-				.verify();
+				.verify(healthCheck.getInterval().multipliedBy(4));
 	}
 
 	@Test
@@ -217,7 +217,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNext(Lists.list())
 				.expectNoEvent(healthCheck.getInterval())
 				.thenCancel()
-				.verify();
+				.verify(healthCheck.getInterval().multipliedBy(4));
 	}
 
 	@Test
@@ -245,7 +245,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.expectNoEvent(healthCheck.getInterval())
 				.expectNext(Lists.list(si1))
 				.thenCancel()
-				.verify();
+				.verify(healthCheck.getInterval().multipliedBy(4));
 	}
 
 	@Test


### PR DESCRIPTION
- WebClient response leaks
- potential Scheduled task leak
- rework polling to plain reactor operators
- remove non atomic operations on ServiceInstance lists

original issue gh-683
related to gh-629