### PR TITLE
Add a utility method to provide a default service id

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
@@ -26,6 +26,11 @@ public final class IdUtils {
 
 	private static final String SEPARATOR = ":";
 
+	// @checkstyle:off
+	public static final String DEFAULT_SERVICE_ID_STRING = "${vcap.application.name:${spring.application.name:application}}:${vcap.application.instance_index:${spring.application.index:${local.server.port:${server.port:0}}}}:${vcap.application.instance_id:${cachedrandom.${vcap.application.name:${spring.application.name:application}}.value}}";
+
+	// @checkstyle:on
+
 	private IdUtils() {
 		throw new IllegalStateException("Can't instantiate a utility class");
 	}
@@ -53,6 +58,23 @@ public final class IdUtils {
 				resolver.getProperty("server.port"));
 
 		return combineParts(namePart, SEPARATOR, indexPart);
+	}
+
+	/**
+	 * Gets the resolved service id.
+	 * @param resolver A property resolved
+	 * @return A unique id that can be used to uniquely identify a service
+	 */
+	public static String getResolvedServiceId(PropertyResolver resolver) {
+		return resolver.resolvePlaceholders(getUnresolvedServiceId());
+	}
+
+	/**
+	 * Gets an the unresolved service id.
+	 * @return The combination of properties to create a unique service id
+	 */
+	public static String getUnresolvedServiceId() {
+		return DEFAULT_SERVICE_ID_STRING;
 	}
 
 	public static String combineParts(String firstPart, String separator,

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/IdUtilsTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/util/IdUtilsTests.java
@@ -111,4 +111,41 @@ public class IdUtilsTests {
 				.as("instanceId was wrong");
 	}
 
+	@Test
+	public void testUnresolvedServiceId() {
+		then(IdUtils.DEFAULT_SERVICE_ID_STRING)
+				.isEqualTo(IdUtils.getUnresolvedServiceId());
+	}
+
+	@Test
+	public void testServiceIdDefaults() {
+		this.env.setProperty("cachedrandom.application.value", "123abc");
+		then("application:0:123abc").isEqualTo(IdUtils.getResolvedServiceId(this.env));
+	}
+
+	@Test
+	public void testVCAPServiceId() {
+		env.setProperty("vcap.application.name", "vcapname");
+		env.setProperty("vcap.application.instance_index", "vcapindex");
+		env.setProperty("vcap.application.instance_id", "vcapid");
+		then("vcapname:vcapindex:vcapid").isEqualTo(IdUtils.getResolvedServiceId(env));
+	}
+
+	@Test
+	public void testSpringServiceId() {
+		env.setProperty("spring.application.name", "springname");
+		env.setProperty("spring.application.index", "springindex");
+		env.setProperty("cachedrandom.springname.value", "123abc");
+		then("springname:springindex:123abc")
+				.isEqualTo(IdUtils.getResolvedServiceId(env));
+	}
+
+	@Test
+	public void testServerPortServiceId() {
+		env.setProperty("spring.application.name", "springname");
+		env.setProperty("server.port", "1234");
+		env.setProperty("cachedrandom.springname.value", "123abc");
+		then("springname:1234:123abc").isEqualTo(IdUtils.getResolvedServiceId(env));
+	}
+
 }


### PR DESCRIPTION
This is moving a utility method from Spring Cloud Bus to commons for more reuse.

I decided against replacing `getDefaultInstanceId` with this new method as I think conceptually a instance id is different than a service id.  