### PR TITLE
Make use of a request factory for filter/interceptor

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerInterceptor.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerInterceptor.java
@@ -45,7 +45,8 @@ public class LoadBalancerInterceptor implements ClientHttpRequestInterceptor {
 
 	private ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory;
 
-	public LoadBalancerInterceptor(ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory,
+	public LoadBalancerInterceptor(
+			ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory,
 			LoadBalancerRequestFactory requestFactory) {
 		this.loadBalancerFactory = loadBalancerFactory;
 		this.requestFactory = requestFactory;
@@ -56,7 +57,8 @@ public class LoadBalancerInterceptor implements ClientHttpRequestInterceptor {
 		this(loadBalancer, new LoadBalancerRequestFactory(loadBalancer));
 	}
 
-	public LoadBalancerInterceptor(LoadBalancerClient loadBalancer, LoadBalancerRequestFactory requestFactory) {
+	public LoadBalancerInterceptor(LoadBalancerClient loadBalancer,
+			LoadBalancerRequestFactory requestFactory) {
 		this.loadBalancer = loadBalancer;
 		this.requestFactory = requestFactory;
 	}
@@ -70,9 +72,11 @@ public class LoadBalancerInterceptor implements ClientHttpRequestInterceptor {
 				"Request URI does not contain a valid hostname: " + originalUri);
 
 		// Locate the actual service
-		ReactiveLoadBalancer<ServiceInstance> lb = loadBalancerFactory.getInstance(serviceName);
+		ReactiveLoadBalancer<ServiceInstance> lb = loadBalancerFactory
+				.getInstance(serviceName);
 
-		Request<?> lbRequest = loadBalancerFactory.getRequestFactory(serviceName).create(request);
+		Request<?> lbRequest = loadBalancerFactory.getRequestFactory(serviceName)
+				.create(request);
 
 		Response<ServiceInstance> response = Mono.from(lb.choose(lbRequest)).block();
 		assert response != null;

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RequestFactory.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RequestFactory.java
@@ -32,6 +32,7 @@ import org.springframework.web.reactive.function.client.ClientRequest;
  * @param <T> Type of the converted request.
  * @author Miran Andaziar
  */
+@FunctionalInterface
 public interface RequestFactory<S, T> {
 
 	T create(S request);
@@ -43,8 +44,7 @@ public interface RequestFactory<S, T> {
 	}
 
 	default Request<?> create(HttpRequest request) {
-		return Optional
-				.ofNullable(request.getHeaders().getFirst("loadBalancerHint"))
+		return Optional.ofNullable(request.getHeaders().getFirst("loadBalancerHint"))
 				.map((Function<Object, DefaultRequest<?>>) DefaultRequest::new)
 				.orElse(new DefaultRequest<>());
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RequestFactory.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RequestFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.client.loadbalancer;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.cloud.client.loadbalancer.reactive.DefaultRequest;
+import org.springframework.cloud.client.loadbalancer.reactive.Request;
+import org.springframework.http.HttpRequest;
+import org.springframework.web.reactive.function.client.ClientRequest;
+
+/**
+ * Request Factory that will be used to convert incoming HTTP request to load balancer
+ * requests.
+ *
+ * @param <S> type of the incoming request
+ * @param <T> Type of the converted request.
+ * @author Miran Andaziar
+ */
+public interface RequestFactory<S, T> {
+
+	T create(S request);
+
+	default Request<?> create(ClientRequest request) {
+		return request.attribute("loadBalancerHint")
+				.map((Function<Object, DefaultRequest<?>>) DefaultRequest::new)
+				.orElse(new DefaultRequest<>());
+	}
+
+	default Request<?> create(HttpRequest request) {
+		return Optional
+				.ofNullable(request.getHeaders().getFirst("loadBalancerHint"))
+				.map((Function<Object, DefaultRequest<?>>) DefaultRequest::new)
+				.orElse(new DefaultRequest<>());
+	}
+
+}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactiveLoadBalancer.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactiveLoadBalancer.java
@@ -46,11 +46,12 @@ public interface ReactiveLoadBalancer<T> {
 		return choose(REQUEST);
 	}
 
-	@FunctionalInterface
 	interface Factory<T> {
+
 		<S, V> RequestFactory<S, V> getRequestFactory(String serviceId);
 
 		ReactiveLoadBalancer<T> getInstance(String serviceId);
+
 	}
 
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactiveLoadBalancer.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactiveLoadBalancer.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.client.loadbalancer.reactive;
 
 import org.reactivestreams.Publisher;
 
+import org.springframework.cloud.client.loadbalancer.RequestFactory;
+
 /**
  * Reactive load balancer.
  *
@@ -46,9 +48,9 @@ public interface ReactiveLoadBalancer<T> {
 
 	@FunctionalInterface
 	interface Factory<T> {
+		<S, V> RequestFactory<S, V> getRequestFactory(String serviceId);
 
 		ReactiveLoadBalancer<T> getInstance(String serviceId);
-
 	}
 
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunction.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunction.java
@@ -63,8 +63,8 @@ public class ReactorLoadBalancerExchangeFilterFunction implements ExchangeFilter
 			return Mono.just(
 					ClientResponse.create(HttpStatus.BAD_REQUEST).body(message).build());
 		}
-		Request<?> lbRequest = loadBalancerFactory
-				.getRequestFactory(serviceId).create(request);
+		Request<?> lbRequest = loadBalancerFactory.getRequestFactory(serviceId)
+				.create(request);
 		return choose(serviceId, lbRequest).flatMap(response -> {
 			ServiceInstance instance = response.getServer();
 			if (instance == null) {

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfigurationTests.java
@@ -24,10 +24,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryFactory;
+import org.springframework.cloud.client.loadbalancer.RequestFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -106,7 +108,19 @@ public class ReactorLoadBalancerClientAutoConfigurationTests {
 
 		@Bean
 		ReactiveLoadBalancer.Factory<ServiceInstance> reactiveLoadBalancerFactory() {
-			return serviceId -> new TestReactiveLoadBalancer();
+			return new ReactiveLoadBalancer.Factory<ServiceInstance>() {
+				@Override
+				public RequestFactory<ClientRequest, Request<?>> getRequestFactory(
+						String serviceId) {
+					return request -> new DefaultRequest<>();
+				}
+
+				@Override
+				public ReactiveLoadBalancer<ServiceInstance> getInstance(
+						String serviceId) {
+					return new TestReactiveLoadBalancer();
+				}
+			};
 		}
 
 		@Bean

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
@@ -36,11 +36,13 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryProperties;
+import org.springframework.cloud.client.loadbalancer.RequestFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -111,8 +113,20 @@ class ReactorLoadBalancerExchangeFilterFunctionTests {
 		@Bean
 		ReactiveLoadBalancer.Factory<ServiceInstance> reactiveLoadBalancerFactory(
 				DiscoveryClient discoveryClient) {
-			return serviceId -> new DiscoveryClientBasedReactiveLoadBalancer(serviceId,
-					discoveryClient);
+			return new ReactiveLoadBalancer.Factory<ServiceInstance>() {
+				@Override
+				public RequestFactory<ClientRequest, Request<?>> getRequestFactory(
+						String serviceId) {
+					return request -> new DefaultRequest<>();
+				}
+
+				@Override
+				public ReactiveLoadBalancer<ServiceInstance> getInstance(
+						String serviceId) {
+					return new DiscoveryClientBasedReactiveLoadBalancer(serviceId,
+							discoveryClient);
+				}
+			};
 		}
 
 	}

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/support/LoadBalancerClientFactory.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/support/LoadBalancerClientFactory.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.loadbalancer.support;
 
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.RequestFactory;
 import org.springframework.cloud.client.loadbalancer.reactive.ReactiveLoadBalancer;
 import org.springframework.cloud.context.named.NamedContextFactory;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClientConfiguration;
@@ -56,8 +57,12 @@ public class LoadBalancerClientFactory
 	}
 
 	@Override
+	public <S, V> RequestFactory<S, V> getRequestFactory(String serviceId) {
+		return getInstance(serviceId, RequestFactory.class);
+	}
+
+	@Override
 	public ReactiveLoadBalancer<ServiceInstance> getInstance(String serviceId) {
 		return getInstance(serviceId, ReactorServiceInstanceLoadBalancer.class);
 	}
-
 }


### PR DESCRIPTION
This PR involves creating a request factory that will be used to convert incoming HTTP requests from ReactorLoadBalancerExchangeFilterFunction/LoadBalancerInterceptor to `org.springframework.cloud.client.loadbalancer.reactive.Request`.

`RequestFactory` has one method that allows developers to plug in their own implementation for doing the conversion `ClientRequest -> Request<?>` or `HttpRequest -> Request<?>` or any other request object for that matter. It also contains default implementations that represents the default strategy of checking the `loadBalancerHint`.