### PR TITLE
Make SimpleReactiveDiscoveryClient react to config changes

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryClient.java
@@ -48,7 +48,8 @@ public class SimpleReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 
 	@Override
 	public Flux<String> getServices() {
-		return Flux.fromIterable(this.simpleDiscoveryProperties.getInstances().keySet());
+		return Flux.defer(() -> Flux
+				.fromIterable(this.simpleDiscoveryProperties.getInstances().keySet()));
 	}
 
 	@Override

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryProperties.java
@@ -57,7 +57,8 @@ public class SimpleReactiveDiscoveryProperties {
 	private int order = DiscoveryClient.DEFAULT_ORDER;
 
 	public Flux<ServiceInstance> getInstances(String service) {
-		return Flux.fromIterable(instances.getOrDefault(service, emptyList()));
+		return Flux.defer(
+				() -> Flux.fromIterable(instances.getOrDefault(service, emptyList())));
 	}
 
 	Map<String, List<SimpleServiceInstance>> getInstances() {


### PR DESCRIPTION
This fixes issue #706 which I found is incorrectly marked as a duplicate.
It seems, at the time my reactive objects are created, the simpleReactiveDiscoveryClient does not yet have the properties set. With that change, it reacts to changes just like the kubernetes implementation already does.