### PR TITLE
The configuration metadata default value for management.endpoint.env.post.enabled should be false instead of true

### DIFF
--- a/spring-cloud-commons/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-commons/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -43,7 +43,7 @@
 			"type": "java.lang.Boolean"
 		},
 		{
-			"defaultValue": true,
+			"defaultValue": false,
 			"name": "management.endpoint.env.post.enabled",
 			"description": "Enables writable environment endpoint.",
 			"type": "java.lang.Boolean"

--- a/spring-cloud-context/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-context/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -10,7 +10,7 @@
 			"name": "management.endpoint.env.post.enabled",
 			"type": "java.lang.Boolean",
 			"description": "Enable changing the Environment through a POST to /env.",
-			"defaultValue": true
+			"defaultValue": false
 		},
 		{
 			"name": "management.endpoint.refresh.enabled",


### PR DESCRIPTION
Fixes #738