### PR TITLE
Spring Cloud Config client don't support removing PropertySource

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
@@ -140,6 +140,19 @@ public class ContextRefresher {
 					}
 				}
 			}
+
+			MutablePropertySources newPropertySources = environment.getPropertySources();
+			List<String> toRemove = new ArrayList<>();
+			// this is a CopyOnWriteArrayList, it doesn't support Iterator.remove
+			for (PropertySource<?> propertySource : target) {
+					String name = propertySource.getName();
+					if (!newPropertySources.contains(name)) {
+						toRemove.add(name);
+					}
+			}
+			for (String name : toRemove) {
+				target.remove(name);
+			}
 		}
 		finally {
 			ConfigurableApplicationContext closeable = capture;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/refresh/ContextRefresherTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/refresh/ContextRefresherTests.java
@@ -75,6 +75,24 @@ public class ContextRefresherTests {
 	}
 
 	@Test
+	public void propertySourceDeleted() {
+		try (ConfigurableApplicationContext context = SpringApplication.run(Empty.class,
+				"--spring.main.web-application-type=none", "--debug=false",
+				"--spring.main.bannerMode=OFF")) {
+			context.getEnvironment().setActiveProfiles("refresh");
+			context.getEnvironment().getPropertySources().addLast(new MapPropertySource("to-remove", Collections.emptyMap()));
+
+			List<String> names = names(context.getEnvironment().getPropertySources());
+			then(names).containsSequence("to-remove");
+
+			ContextRefresher refresher = new ContextRefresher(context, this.scope);
+			refresher.refresh();
+			names = names(context.getEnvironment().getPropertySources());
+			then(names).doesNotContain("to-remove");
+		}
+	}
+
+	@Test
 	public void bootstrapPropertySourceAlwaysFirst() {
 		// Use spring.cloud.bootstrap.name to switch off the defaults (which would pick up
 		// a bootstrapProperties immediately


### PR DESCRIPTION
We saw a regression in the Spring Cloud Config client.
We use it with Spring Cloud Config Server servicing files hosted in a
Git repository. We sometimes need to remove some configuration file from
the repository.
Since https://github.com/spring-cloud/spring-cloud-commons/issues/611
was merged, our applications can not detect when such a file is deleted.

The explanation is that before #611, the PropertySources (PS) were
wrapped in a CompositePropertySource, and then ContextRefresher.addConfigFilesToEnvironment() would
match the names and replace the old CompositePropertySource wrapping all
the PS including the one that was removed with the new CompositePropertySource that do not contains it, and all is fine.

After #611, we have a list of PS, and we would only update the existing
PS or add new ones but never detect that a PS was removed.

Here is a proposed fix, but any suggestion or modifications are welcome.
What is probably missing is a filter to only remove PropertySources that where loaded from the Config Server, as in the current state this PR causes integration test RefreshEndpointIntegrationTests to fail.