### PR TITLE
Add ConditionalOnMissingBean to SimpleDiscoveryProperties.

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.cloud.client.CommonsClientAutoConfiguration;
@@ -57,6 +58,7 @@ public class SimpleDiscoveryClientAutoConfiguration
 	private SimpleDiscoveryProperties simple = new SimpleDiscoveryProperties();
 
 	@Bean
+	@ConditionalOnMissingBean
 	public SimpleDiscoveryProperties simpleDiscoveryProperties() {
 		simple.getLocal().setServiceId(this.serviceId);
 		simple.getLocal()


### PR DESCRIPTION
The makes SimpleDiscoveryClientAutoConfiguration less invasive.

Fixes spring-cloud/spring-cloud-commons#759