### PR TITLE
Add probe method to DiscoveryClient

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -8,7 +8,8 @@
 |spring.cloud.config.override-system-properties | true | Flag to indicate that the external properties should override system properties. Default true.
 |spring.cloud.discovery.client.composite-indicator.enabled | true | Enables discovery client composite health indicator.
 |spring.cloud.discovery.client.health-indicator.enabled | true | 
-|spring.cloud.discovery.client.health-indicator.include-description | false | 
+|spring.cloud.discovery.client.health-indicator.include-description | false |
+|spring.cloud.discovery.client.health-indicator.use-services-query | false | Whether the indicator should query for all registered services or use probe method.
 |spring.cloud.discovery.client.simple.instances |  | 
 |spring.cloud.discovery.client.simple.local.instance-id |  | The unique identifier or name for the service instance.
 |spring.cloud.discovery.client.simple.local.metadata |  | Metadata for the service instance. Can be used by discovery clients to modify their behaviour per instance, e.g. when load balancing.

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
@@ -27,6 +27,7 @@ import org.springframework.core.Ordered;
  *
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author Chris Bono
  */
 public interface DiscoveryClient extends Ordered {
 
@@ -52,6 +53,19 @@ public interface DiscoveryClient extends Ordered {
 	 * @return All known service IDs.
 	 */
 	List<String> getServices();
+
+	/**
+	 * Can be used to verify the client is valid and able to make calls.
+	 * <p>
+	 * A successful invocation with no exception thrown implies the client is able to make
+	 * calls.
+	 * <p>
+	 * The default implementation simply calls {@link #getServices()} - client
+	 * implementations can override with a lighter weight operation if they choose to.
+	 */
+	default void probe() {
+		getServices();
+	}
 
 	/**
 	 * Default implementation for getting order of discovery clients.

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ReactiveDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ReactiveDiscoveryClient.java
@@ -53,6 +53,19 @@ public interface ReactiveDiscoveryClient extends Ordered {
 	Flux<String> getServices();
 
 	/**
+	 * Can be used to verify the client is still valid and able to make calls.
+	 * <p>
+	 * A successful invocation with no exception thrown implies the client is able to make
+	 * calls.
+	 * <p>
+	 * The default implementation simply calls {@link #getServices()} - client
+	 * implementations can override with a lighter weight operation if they choose to.
+	 */
+	default void probe() {
+		getServices();
+	}
+
+	/**
 	 * Default implementation for getting order of discovery clients.
 	 * @return order
 	 */

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicator.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicator.java
@@ -32,6 +32,7 @@ import org.springframework.core.Ordered;
 
 /**
  * @author Spencer Gibb
+ * @author Chris Bono
  */
 public class DiscoveryClientHealthIndicator implements DiscoveryHealthIndicator, Ordered,
 		ApplicationListener<InstanceRegisteredEvent<?>> {
@@ -66,11 +67,18 @@ public class DiscoveryClientHealthIndicator implements DiscoveryHealthIndicator,
 		if (this.discoveryInitialized.get()) {
 			try {
 				DiscoveryClient client = this.discoveryClient.getIfAvailable();
-				List<String> services = client.getServices();
 				String description = (this.properties.isIncludeDescription())
 						? client.description() : "";
-				builder.status(new Status("UP", description)).withDetail("services",
-						services);
+
+				if (properties.isUseServicesQuery()) {
+					List<String> services = client.getServices();
+					builder.status(new Status("UP", description)).withDetail("services",
+							services);
+				}
+				else {
+					client.probe();
+					builder.status(new Status("UP", description));
+				}
 			}
 			catch (Exception e) {
 				this.log.error("Error", e);

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
@@ -28,6 +28,8 @@ public class DiscoveryClientHealthIndicatorProperties {
 
 	private boolean includeDescription = false;
 
+	private boolean useServicesQuery = false;
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -44,12 +46,21 @@ public class DiscoveryClientHealthIndicatorProperties {
 		this.includeDescription = includeDescription;
 	}
 
+	public boolean isUseServicesQuery() {
+		return useServicesQuery;
+	}
+
+	public void setUseServicesQuery(boolean useServicesQuery) {
+		this.useServicesQuery = useServicesQuery;
+	}
+
 	@Override
 	public String toString() {
 		final StringBuffer sb = new StringBuffer(
 				"DiscoveryClientHealthIndicatorProperties{");
 		sb.append("enabled=").append(this.enabled);
 		sb.append(", includeDescription=").append(this.includeDescription);
+		sb.append(", useServicesQuery=").append(this.useServicesQuery);
 		sb.append('}');
 		return sb.toString();
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/reactive/ReactiveDiscoveryClientHealthIndicator.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/reactive/ReactiveDiscoveryClientHealthIndicator.java
@@ -37,6 +37,7 @@ import static java.util.Collections.emptyList;
  * initialized.
  *
  * @author Tim Ysewyn
+ * @author Chris Bono
  */
 public class ReactiveDiscoveryClientHealthIndicator
 		implements ReactiveDiscoveryHealthIndicator, Ordered,
@@ -79,20 +80,40 @@ public class ReactiveDiscoveryClientHealthIndicator
 
 	private Mono<Health> doHealthCheck() {
 		// @formatter:off
+		return Mono.just(this.properties.isUseServicesQuery())
+				.flatMap(useServices -> useServices ? doHealthCheckWithServices() : doHealthCheckWithProbe())
+				.onErrorResume(exception -> {
+					this.log.error("Error", exception);
+					return Mono.just(Health.down().withException(exception).build());
+				});
+		// @formatter:on
+	}
+
+	private Mono<Health> doHealthCheckWithProbe() {
+		// @formatter:off
+		return Mono.justOrEmpty(this.discoveryClient)
+				.flatMap(client -> {
+					client.probe();
+					return Mono.just(client);
+				})
+				.map(client -> {
+					String description = (this.properties.isIncludeDescription()) ? client.description() : "";
+					return Health.status(new Status("UP", description)).build();
+				});
+		// @formatter:on
+	}
+
+	private Mono<Health> doHealthCheckWithServices() {
+		// @formatter:off
 		return Mono.justOrEmpty(this.discoveryClient)
 				.flatMapMany(ReactiveDiscoveryClient::getServices)
 				.collectList()
 				.defaultIfEmpty(emptyList())
 				.map(services -> {
-					ReactiveDiscoveryClient client = this.discoveryClient;
-					String description = (this.properties.isIncludeDescription())
-							? client.description() : "";
+					String description = (this.properties.isIncludeDescription()) ?
+						this.discoveryClient.description() : "";
 					return Health.status(new Status("UP", description))
-							.withDetail("services", services).build();
-				})
-				.onErrorResume(exception -> {
-					this.log.error("Error", exception);
-					return Mono.just(Health.down().withException(exception).build());
+						.withDetail("services", services).build();
 				});
 		// @formatter:on
 	}


### PR DESCRIPTION
Adds a probe method to `Reactive/DiscoveryClient` and optionally use in `Reactive/DiscoveryClientHealthIndicator`. 

Fixes gh-785.

@spencergibb this is the follow on to the change in [ConsulHealthIndicator](https://github.com/spring-cloud/spring-cloud-consul/pull/651). 