### PR TITLE
Add probe method to DiscoveryClient 

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -9,8 +9,7 @@
 |spring.cloud.discovery.client.composite-indicator.enabled | true | Enables discovery client composite health indicator.
 |spring.cloud.discovery.client.health-indicator.enabled | true | 
 |spring.cloud.discovery.client.health-indicator.include-description | false |
-|spring.cloud.discovery.client.health-indicator.use-services-query | true | Whether the indicator should query for all registered services or use probe method.
-|spring.cloud.discovery.client.simple.instances |  | 
+|spring.cloud.discovery.client.simple.instances |  |
 |spring.cloud.discovery.client.simple.local.instance-id |  | The unique identifier or name for the service instance.
 |spring.cloud.discovery.client.simple.local.metadata |  | Metadata for the service instance. Can be used by discovery clients to modify their behaviour per instance, e.g. when load balancing.
 |spring.cloud.discovery.client.simple.local.service-id |  | The identifier or name for the service. Multiple instances might share the same service ID.

--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -8,7 +8,8 @@
 |spring.cloud.config.override-system-properties | true | Flag to indicate that the external properties should override system properties. Default true.
 |spring.cloud.discovery.client.composite-indicator.enabled | true | Enables discovery client composite health indicator.
 |spring.cloud.discovery.client.health-indicator.enabled | true | 
-|spring.cloud.discovery.client.health-indicator.include-description | false | 
+|spring.cloud.discovery.client.health-indicator.include-description | false |
+|spring.cloud.discovery.client.health-indicator.use-services-query | true | Whether the indicator should query for all registered services or use probe method.
 |spring.cloud.discovery.client.simple.instances |  | 
 |spring.cloud.discovery.client.simple.local.instance-id |  | The unique identifier or name for the service instance.
 |spring.cloud.discovery.client.simple.local.metadata |  | Metadata for the service instance. Can be used by discovery clients to modify their behaviour per instance, e.g. when load balancing.

--- a/docs/src/main/asciidoc/spring-cloud-commons.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-commons.adoc
@@ -257,14 +257,22 @@ This behavior can be disabled by setting `autoRegister=false` in `@EnableDiscove
 NOTE: `@EnableDiscoveryClient` is no longer required.
 You can put a `DiscoveryClient` implementation on the classpath to cause the Spring Boot application to register with the service discovery server.
 
-==== Health Indicator
+==== Health Indicators
 
-Commons creates a Spring Boot `HealthIndicator` that `DiscoveryClient` implementations can participate in by implementing `DiscoveryHealthIndicator`.
-To disable the composite `HealthIndicator`, set `spring.cloud.discovery.client.composite-indicator.enabled=false`.
-A generic `HealthIndicator` based on `DiscoveryClient` is auto-configured (`DiscoveryClientHealthIndicator`).
-To disable it, set `spring.cloud.discovery.client.health-indicator.enabled=false`.
-To disable the description field of the `DiscoveryClientHealthIndicator`, set `spring.cloud.discovery.client.health-indicator.include-description=false`.
+Commons auto-configures the following Spring Boot health indicators.
+
+===== DiscoveryClientHealthIndicator
+This health indicator is based on the currently registered `DiscoveryClient` implementation.
+
+* To disable entirely, set `spring.cloud.discovery.client.health-indicator.enabled=false`.
+* To disable the description field, set `spring.cloud.discovery.client.health-indicator.include-description=false`.
 Otherwise, it can bubble up as the `description` of the rolled up `HealthIndicator`.
+* To perform a lightweight check using the client's `probe` method, set `spring.cloud.discovery.client.health-indicator.use-services-query=false`.
+Otherwise, the client's `getServices` method will be used.
+
+===== DiscoveryCompositeHealthContributor
+This composite health indicator is based on all registered `DiscoveryHealthIndicator` beans. To disable,
+set `spring.cloud.discovery.client.composite-indicator.enabled=false`.
 
 ==== Ordering `DiscoveryClient` instances
 `DiscoveryClient` interface extends `Ordered`. This is useful when using multiple discovery

--- a/docs/src/main/asciidoc/spring-cloud-commons.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-commons.adoc
@@ -267,8 +267,9 @@ This health indicator is based on the currently registered `DiscoveryClient` imp
 * To disable entirely, set `spring.cloud.discovery.client.health-indicator.enabled=false`.
 * To disable the description field, set `spring.cloud.discovery.client.health-indicator.include-description=false`.
 Otherwise, it can bubble up as the `description` of the rolled up `HealthIndicator`.
-* To perform a lightweight check using the client's `probe` method, set `spring.cloud.discovery.client.health-indicator.use-services-query=false`.
-Otherwise, the client's `getServices` method will be used.
+* To disable service retrieval, set `spring.cloud.discovery.client.health-indicator.use-services-query=false`.
+By default, the indicator invokes the client's `getServices` method. In deployments with many registered services it may too
+costly to retrieve all services during every check. This will skip the service retrieval and instead use the client's `probe` method.
 
 ===== DiscoveryCompositeHealthContributor
 This composite health indicator is based on all registered `DiscoveryHealthIndicator` beans. To disable,

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java
@@ -27,6 +27,7 @@ import org.springframework.core.Ordered;
  *
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author Chris Bono
  */
 public interface DiscoveryClient extends Ordered {
 
@@ -52,6 +53,19 @@ public interface DiscoveryClient extends Ordered {
 	 * @return All known service IDs.
 	 */
 	List<String> getServices();
+
+	/**
+	 * Can be used to verify the client is valid and able to make calls.
+	 * <p>
+	 * A successful invocation with no exception thrown implies the client is able to make
+	 * calls.
+	 * <p>
+	 * The default implementation simply calls {@link #getServices()} - client
+	 * implementations can override with a lighter weight operation if they choose to.
+	 */
+	default void probe() {
+		getServices();
+	}
 
 	/**
 	 * Default implementation for getting order of discovery clients.

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ReactiveDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/ReactiveDiscoveryClient.java
@@ -53,6 +53,19 @@ public interface ReactiveDiscoveryClient extends Ordered {
 	Flux<String> getServices();
 
 	/**
+	 * Can be used to verify the client is still valid and able to make calls.
+	 * <p>
+	 * A successful invocation with no exception thrown implies the client is able to make
+	 * calls.
+	 * <p>
+	 * The default implementation simply calls {@link #getServices()} - client
+	 * implementations can override with a lighter weight operation if they choose to.
+	 */
+	default void probe() {
+		getServices();
+	}
+
+	/**
 	 * Default implementation for getting order of discovery clients.
 	 * @return order
 	 */

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicator.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicator.java
@@ -32,6 +32,7 @@ import org.springframework.core.Ordered;
 
 /**
  * @author Spencer Gibb
+ * @author Chris Bono
  */
 public class DiscoveryClientHealthIndicator implements DiscoveryHealthIndicator, Ordered,
 		ApplicationListener<InstanceRegisteredEvent<?>> {
@@ -66,11 +67,18 @@ public class DiscoveryClientHealthIndicator implements DiscoveryHealthIndicator,
 		if (this.discoveryInitialized.get()) {
 			try {
 				DiscoveryClient client = this.discoveryClient.getIfAvailable();
-				List<String> services = client.getServices();
 				String description = (this.properties.isIncludeDescription())
 						? client.description() : "";
-				builder.status(new Status("UP", description)).withDetail("services",
-						services);
+
+				if (properties.isUseServicesQuery()) {
+					List<String> services = client.getServices();
+					builder.status(new Status("UP", description)).withDetail("services",
+							services);
+				}
+				else {
+					client.probe();
+					builder.status(new Status("UP", description));
+				}
 			}
 			catch (Exception e) {
 				this.log.error("Error", e);

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
@@ -28,6 +28,8 @@ public class DiscoveryClientHealthIndicatorProperties {
 
 	private boolean includeDescription = false;
 
+	private boolean useServicesQuery = true;
+
 	public boolean isEnabled() {
 		return this.enabled;
 	}
@@ -44,12 +46,21 @@ public class DiscoveryClientHealthIndicatorProperties {
 		this.includeDescription = includeDescription;
 	}
 
+	public boolean isUseServicesQuery() {
+		return useServicesQuery;
+	}
+
+	public void setUseServicesQuery(boolean useServicesQuery) {
+		this.useServicesQuery = useServicesQuery;
+	}
+
 	@Override
 	public String toString() {
 		final StringBuffer sb = new StringBuffer(
 				"DiscoveryClientHealthIndicatorProperties{");
 		sb.append("enabled=").append(this.enabled);
 		sb.append(", includeDescription=").append(this.includeDescription);
+		sb.append(", useServicesQuery=").append(this.useServicesQuery);
 		sb.append('}');
 		return sb.toString();
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.client.discovery.health;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 
 /**
  * @author Spencer Gibb
@@ -28,6 +29,12 @@ public class DiscoveryClientHealthIndicatorProperties {
 
 	private boolean includeDescription = false;
 
+	/**
+	 * Whether or not the indicator should use {@link DiscoveryClient#getServices} to
+	 * check its health. When set to {@code false} the indicator instead uses the lighter
+	 * {@link DiscoveryClient#probe()}. This can be helpful in large deployments where the
+	 * number of services returned makes the operation unnecessarily heavy.
+	 */
 	private boolean useServicesQuery = true;
 
 	public boolean isEnabled() {

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/reactive/ReactiveDiscoveryClientHealthIndicator.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/health/reactive/ReactiveDiscoveryClientHealthIndicator.java
@@ -37,6 +37,7 @@ import static java.util.Collections.emptyList;
  * initialized.
  *
  * @author Tim Ysewyn
+ * @author Chris Bono
  */
 public class ReactiveDiscoveryClientHealthIndicator
 		implements ReactiveDiscoveryHealthIndicator, Ordered,
@@ -79,20 +80,40 @@ public class ReactiveDiscoveryClientHealthIndicator
 
 	private Mono<Health> doHealthCheck() {
 		// @formatter:off
+		return Mono.just(this.properties.isUseServicesQuery())
+				.flatMap(useServices -> useServices ? doHealthCheckWithServices() : doHealthCheckWithProbe())
+				.onErrorResume(exception -> {
+					this.log.error("Error", exception);
+					return Mono.just(Health.down().withException(exception).build());
+				});
+		// @formatter:on
+	}
+
+	private Mono<Health> doHealthCheckWithProbe() {
+		// @formatter:off
+		return Mono.justOrEmpty(this.discoveryClient)
+				.flatMap(client -> {
+					client.probe();
+					return Mono.just(client);
+				})
+				.map(client -> {
+					String description = (this.properties.isIncludeDescription()) ? client.description() : "";
+					return Health.status(new Status("UP", description)).build();
+				});
+		// @formatter:on
+	}
+
+	private Mono<Health> doHealthCheckWithServices() {
+		// @formatter:off
 		return Mono.justOrEmpty(this.discoveryClient)
 				.flatMapMany(ReactiveDiscoveryClient::getServices)
 				.collectList()
 				.defaultIfEmpty(emptyList())
 				.map(services -> {
-					ReactiveDiscoveryClient client = this.discoveryClient;
-					String description = (this.properties.isIncludeDescription())
-							? client.description() : "";
+					String description = (this.properties.isIncludeDescription()) ?
+						this.discoveryClient.description() : "";
 					return Health.status(new Status("UP", description))
-							.withDetail("services", services).build();
-				})
-				.onErrorResume(exception -> {
-					this.log.error("Error", exception);
-					return Mono.just(Health.down().withException(exception).build());
+						.withDetail("services", services).build();
 				});
 		// @formatter:on
 	}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorUnitTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorUnitTests.java
@@ -14,57 +14,54 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.client.discovery.health.reactive;
+package org.springframework.cloud.client.discovery.health;
 
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
-import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
-import org.springframework.cloud.client.discovery.health.DiscoveryClientHealthIndicatorProperties;
-import org.springframework.core.Ordered;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Tim Ysewyn
+ * Unit tests for {@link DiscoveryClientHealthIndicator}.
+ *
  * @author Chris Bono
  */
 @ExtendWith(MockitoExtension.class)
-class ReactiveDiscoveryClientHealthIndicatorTests {
+class DiscoveryClientHealthIndicatorUnitTests {
 
 	@Mock
-	private ReactiveDiscoveryClient discoveryClient;
+	private ObjectProvider<DiscoveryClient> discoveryClientProvider;
+
+	@Mock
+	private DiscoveryClient discoveryClient;
 
 	@Mock
 	private DiscoveryClientHealthIndicatorProperties properties;
 
 	@InjectMocks
-	private ReactiveDiscoveryClientHealthIndicator indicator;
+	private DiscoveryClientHealthIndicator indicator;
 
-	@Test
-	public void shouldReturnCorrectOrder() {
-		assertThat(indicator.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
-		indicator.setOrder(0);
-		assertThat(indicator.getOrder()).isEqualTo(0);
-	}
-
-	@Test
-	public void shouldUseClientDescriptionForIndicatorName() {
-		when(discoveryClient.description()).thenReturn("Mocked Service Discovery Client");
-		assertThat(indicator.getName()).isEqualTo("Mocked Service Discovery Client");
+	@BeforeEach
+	public void prepareMocks() {
+		lenient().when(discoveryClientProvider.getIfAvailable())
+				.thenReturn(discoveryClient);
 	}
 
 	@Test
@@ -72,8 +69,8 @@ class ReactiveDiscoveryClientHealthIndicatorTests {
 		Health expectedHealth = Health.status(
 				new Status(Status.UNKNOWN.getCode(), "Discovery Client not initialized"))
 				.build();
-		Mono<Health> health = indicator.health();
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		Health health = indicator.health();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 	@Test
@@ -83,9 +80,9 @@ class ReactiveDiscoveryClientHealthIndicatorTests {
 				.build();
 
 		indicator.onApplicationEvent(new InstanceRegisteredEvent<>(this, null));
-		Mono<Health> health = indicator.health();
+		Health health = indicator.health();
 
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 	@Test
@@ -96,52 +93,52 @@ class ReactiveDiscoveryClientHealthIndicatorTests {
 		Health expectedHealth = Health.down(ex).build();
 
 		indicator.onApplicationEvent(new InstanceRegisteredEvent<>(this, null));
-		Mono<Health> health = indicator.health();
+		Health health = indicator.health();
 
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 	@Test
 	public void shouldReturnUpStatusWhenUsingServicesQueryAndNoServicesReturned() {
 		when(properties.isUseServicesQuery()).thenReturn(true);
-		when(discoveryClient.getServices()).thenReturn(Flux.empty());
+		when(discoveryClient.getServices()).thenReturn(Collections.emptyList());
 		Health expectedHealth = Health.status(new Status(Status.UP.getCode(), ""))
 				.withDetail("services", emptyList()).build();
 
 		indicator.onApplicationEvent(new InstanceRegisteredEvent<>(this, null));
-		Mono<Health> health = indicator.health();
+		Health health = indicator.health();
 
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 	@Test
 	public void shouldReturnUpStatusWhenUsingServicesQueryAndServicesReturned() {
 		when(properties.isUseServicesQuery()).thenReturn(true);
 		when(properties.isIncludeDescription()).thenReturn(true);
-		when(discoveryClient.getServices()).thenReturn(Flux.just("service"));
 		when(discoveryClient.description()).thenReturn("Mocked Service Discovery Client");
+		when(discoveryClient.getServices()).thenReturn(singletonList("service"));
 		Health expectedHealth = Health
 				.status(new Status(Status.UP.getCode(),
 						"Mocked Service Discovery Client"))
 				.withDetail("services", singletonList("service")).build();
 
 		indicator.onApplicationEvent(new InstanceRegisteredEvent<>(this, null));
-		Mono<Health> health = indicator.health();
+		Health health = indicator.health();
 
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 	@Test
 	public void shouldReturnDownStatusWhenUsingServicesQueryAndCallFails() {
 		when(properties.isUseServicesQuery()).thenReturn(true);
 		RuntimeException ex = new RuntimeException("something went wrong");
-		when(discoveryClient.getServices()).thenReturn(Flux.error(ex));
+		when(discoveryClient.getServices()).thenThrow(ex);
 		Health expectedHealth = Health.down(ex).build();
 
 		indicator.onApplicationEvent(new InstanceRegisteredEvent<>(this, null));
-		Mono<Health> health = indicator.health();
+		Health health = indicator.health();
 
-		StepVerifier.create(health).expectNext(expectedHealth).expectComplete().verify();
+		assertThat(health).isEqualTo(expectedHealth);
 	}
 
 }


### PR DESCRIPTION
Adds a probe method to Reactive/DiscoveryClient and optionally use in Reactive/DiscoveryClientHealthIndicator.

Fixes gh-785.

@ryanjbaxter - here is the 2.2.x version.