### PR TITLE
Remove URL check that causes loading 401 responses from Spring Cloud …

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
@@ -50,7 +50,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
-import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
@@ -140,7 +139,6 @@ public class PropertySourceBootstrapConfiguration implements
 			LoggingSystem system = LoggingSystem
 					.get(LoggingSystem.class.getClassLoader());
 			try {
-				ResourceUtils.getURL(logConfig).openStream().close();
 				// Three step initialization that accounts for the clean up of the logging
 				// context before initialization. Spring Boot doesn't initialize a logging
 				// system that hasn't had this sequence applied (since 1.4.1).


### PR DESCRIPTION
Log4j 2 provides enhanced Spring Boot and Spring Cloud Config support with its log4j-spring-boot and log4j-spring-cloud-config-client modules. The Spring Cloud Config Client allows Log4j configuration files to be managed in Spring Cloud Config allowing for dynamic updating of the configuration, configurable SSL support, and support for credentials to access Spring Cloud Config server.

Unfortunately, Spring Cloud Commons' PropertySourceBootstrapConfiguration class causes a 401 error response when trying to access a logging configuration file from Spring Cloud Configuration server when credentials are required. This check really provides no value since the underlying LoggingSystem will throw an exception if the url cannot be accessed, and because it does not include credentials it results in a 401 response that prevents the Spring Boot application from starting if credentials are required to access the Spring Cloud Configuration server.