### PR TITLE
Rewrite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,24 @@
 	<build>
 		<plugins>
 			<plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.spring</recipe>
+                    </activeRecipes>
+					<sourceTypes>
+						<type>java</type>
+					</sourceTypes>
+					<activeStyles>
+						<style>io.moderne.spring.style</style>
+					</activeStyles>
+                    <metricsUri>LOG</metricsUri>
+                    <configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
+                </configuration>
+            </plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
@@ -174,4 +192,11 @@
 		<module>spring-cloud-starter-loadbalancer</module>
 		<module>docs</module>
 	</modules>
+	<dependencies>
+		<dependency>
+			<groupId>org.openrewrite.plan</groupId>
+			<artifactId>rewrite-spring</artifactId>
+			<version>2.2.0-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,19 @@
+---
+type: specs.openrewrite.org/v1beta/style
+name: io.moderne.spring.style
+
+configure:
+  org.openrewrite.java.style.ImportLayoutStyle:
+    layout:
+      classCountToUseStarImport: 999
+      nameCountToUseStarImport: 999
+      blocks:
+        - import java.*
+        - <blank line>
+        - import javax.*
+        - <blank line>
+        - import all other imports
+        - <blank line>
+        - import org.springframework.*
+        - <blank line>
+        - import static all other imports

--- a/spring-cloud-commons-dependencies/pom.xml
+++ b/spring-cloud-commons-dependencies/pom.xml
@@ -17,6 +17,35 @@
 	<properties>
 		<spring-security-rsa.version>1.0.9.RELEASE</spring-security-rsa.version>
 	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.openrewrite.plan</groupId>
+			<artifactId>rewrite-spring</artifactId>
+			<version>2.2.0-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.spring</recipe>
+                    </activeRecipes>
+					<sourceTypes>
+						<type>java</type>
+					</sourceTypes>
+					<activeStyles>
+						<style>io.moderne.spring.style</style>
+					</activeStyles>
+                    <metricsUri>LOG</metricsUri>
+                    <configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/CommonsClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/CommonsClientAutoConfiguration.java
@@ -60,7 +60,7 @@ public class CommonsClientAutoConfiguration {
 
 		@Bean
 		@ConditionalOnDiscoveryHealthIndicatorEnabled
-		public DiscoveryClientHealthIndicator discoveryClientHealthIndicator(
+		DiscoveryClientHealthIndicator discoveryClientHealthIndicator(
 				ObjectProvider<DiscoveryClient> discoveryClient,
 				DiscoveryClientHealthIndicatorProperties properties) {
 			return new DiscoveryClientHealthIndicator(discoveryClient, properties);
@@ -71,13 +71,13 @@ public class CommonsClientAutoConfiguration {
 				value = "spring.cloud.discovery.client.composite-indicator.enabled",
 				matchIfMissing = true)
 		@ConditionalOnBean({ DiscoveryHealthIndicator.class })
-		public DiscoveryCompositeHealthContributor discoveryCompositeHealthContributor(
+		DiscoveryCompositeHealthContributor discoveryCompositeHealthContributor(
 				List<DiscoveryHealthIndicator> indicators) {
 			return new DiscoveryCompositeHealthContributor(indicators);
 		}
 
 		@Bean
-		public HasFeatures commonsFeatures() {
+		HasFeatures commonsFeatures() {
 			return HasFeatures.abstractFeatures(DiscoveryClient.class,
 					LoadBalancerClient.class);
 		}
@@ -94,7 +94,7 @@ public class CommonsClientAutoConfiguration {
 
 		@Bean
 		@ConditionalOnAvailableEndpoint
-		public FeaturesEndpoint featuresEndpoint() {
+		FeaturesEndpoint featuresEndpoint() {
 			return new FeaturesEndpoint(this.hasFeatures);
 		}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ReactiveCommonsClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/ReactiveCommonsClientAutoConfiguration.java
@@ -56,13 +56,13 @@ public class ReactiveCommonsClientAutoConfiguration {
 				value = "spring.cloud.discovery.client.composite-indicator.enabled",
 				matchIfMissing = true)
 		@ConditionalOnBean({ ReactiveDiscoveryHealthIndicator.class })
-		public ReactiveDiscoveryCompositeHealthContributor reactiveDiscoveryClients(
+		ReactiveDiscoveryCompositeHealthContributor reactiveDiscoveryClients(
 				Collection<ReactiveDiscoveryHealthIndicator> indicators) {
 			return new ReactiveDiscoveryCompositeHealthContributor(indicators);
 		}
 
 		@Bean
-		public HasFeatures reactiveCommonsFeatures() {
+		HasFeatures reactiveCommonsFeatures() {
 			return HasFeatures.abstractFeatures(ReactiveDiscoveryClient.class,
 					ReactiveLoadBalancer.class);
 		}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientAutoConfiguration.java
@@ -37,7 +37,7 @@ public class CompositeDiscoveryClientAutoConfiguration {
 
 	@Bean
 	@Primary
-	public CompositeDiscoveryClient compositeDiscoveryClient(
+	CompositeDiscoveryClient compositeDiscoveryClient(
 			List<DiscoveryClient> discoveryClients) {
 		return new CompositeDiscoveryClient(discoveryClients);
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClientAutoConfiguration.java
@@ -38,7 +38,7 @@ public class ReactiveCompositeDiscoveryClientAutoConfiguration {
 
 	@Bean
 	@Primary
-	public ReactiveCompositeDiscoveryClient reactiveCompositeDiscoveryClient(
+	ReactiveCompositeDiscoveryClient reactiveCompositeDiscoveryClient(
 			List<ReactiveDiscoveryClient> discoveryClients) {
 		return new ReactiveCompositeDiscoveryClient(discoveryClients);
 	}

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/noop/NoopDiscoveryClientAutoConfiguration.java
@@ -110,7 +110,7 @@ public class NoopDiscoveryClientAutoConfiguration
 	}
 
 	@Bean
-	public DiscoveryClient discoveryClient() {
+	DiscoveryClient discoveryClient() {
 		return new NoopDiscoveryClient(this.serviceInstance);
 	}
 
@@ -127,7 +127,7 @@ public class NoopDiscoveryClientAutoConfiguration
 	protected static class Boot15PortFinderConfiguration {
 
 		@Bean
-		public PortFinder portFinder(final ApplicationContext context) {
+		PortFinder portFinder(final ApplicationContext context) {
 			return new PortFinder() {
 				@Override
 				public Integer findPort() {

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientAutoConfiguration.java
@@ -64,7 +64,7 @@ public class SimpleDiscoveryClientAutoConfiguration
 
 	@Bean
 	@ConditionalOnMissingBean
-	public SimpleDiscoveryProperties simpleDiscoveryProperties(
+	SimpleDiscoveryProperties simpleDiscoveryProperties(
 			@Value("${spring.application.name:application}") String serviceId) {
 		simple.getLocal().setServiceId(serviceId);
 		simple.getLocal()
@@ -76,7 +76,7 @@ public class SimpleDiscoveryClientAutoConfiguration
 
 	@Bean
 	@Order
-	public DiscoveryClient simpleDiscoveryClient(SimpleDiscoveryProperties properties) {
+	DiscoveryClient simpleDiscoveryClient(SimpleDiscoveryProperties properties) {
 		return new SimpleDiscoveryClient(properties);
 	}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/simple/reactive/SimpleReactiveDiscoveryClientAutoConfiguration.java
@@ -69,7 +69,7 @@ public class SimpleReactiveDiscoveryClientAutoConfiguration
 	private SimpleReactiveDiscoveryProperties simple = new SimpleReactiveDiscoveryProperties();
 
 	@Bean
-	public SimpleReactiveDiscoveryProperties simpleReactiveDiscoveryProperties() {
+	SimpleReactiveDiscoveryProperties simpleReactiveDiscoveryProperties() {
 		simple.getLocal().setServiceId(serviceId);
 		simple.getLocal().setUri(URI.create("http://"
 				+ inet.findFirstNonLoopbackHostInfo().getHostname() + ":" + findPort()));
@@ -78,7 +78,7 @@ public class SimpleReactiveDiscoveryClientAutoConfiguration
 
 	@Bean
 	@Order
-	public SimpleReactiveDiscoveryClient simpleReactiveDiscoveryClient() {
+	SimpleReactiveDiscoveryClient simpleReactiveDiscoveryClient() {
 		return new SimpleReactiveDiscoveryClient(simpleReactiveDiscoveryProperties());
 	}
 
@@ -107,7 +107,7 @@ public class SimpleReactiveDiscoveryClientAutoConfiguration
 
 		@Bean
 		@ConditionalOnDiscoveryHealthIndicatorEnabled
-		public ReactiveDiscoveryClientHealthIndicator simpleReactiveDiscoveryClientHealthIndicator(
+		ReactiveDiscoveryClientHealthIndicator simpleReactiveDiscoveryClientHealthIndicator(
 				DiscoveryClientHealthIndicatorProperties properties,
 				SimpleReactiveDiscoveryClient simpleReactiveDiscoveryClient) {
 			return new ReactiveDiscoveryClientHealthIndicator(

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/hypermedia/CloudHypermediaAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/hypermedia/CloudHypermediaAutoConfiguration.java
@@ -48,7 +48,7 @@ public class CloudHypermediaAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public RemoteResourceRefresher discoveredResourceRefresher() {
+	RemoteResourceRefresher discoveredResourceRefresher() {
 		return new RemoteResourceRefresher(this.discoveredResources,
 				this.properties.getRefresh().getFixedDelay(),
 				this.properties.getRefresh().getInitialDelay());

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/AsyncLoadBalancerAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/AsyncLoadBalancerAutoConfiguration.java
@@ -47,7 +47,7 @@ public class AsyncLoadBalancerAutoConfiguration {
 		private List<AsyncRestTemplate> restTemplates = Collections.emptyList();
 
 		@Bean
-		public SmartInitializingSingleton loadBalancedAsyncRestTemplateInitializer(
+		SmartInitializingSingleton loadBalancedAsyncRestTemplateInitializer(
 				final List<AsyncRestTemplateCustomizer> customizers) {
 			return () -> {
 				for (AsyncRestTemplate restTemplate : AsyncRestTemplateCustomizerConfig.this.restTemplates) {
@@ -64,13 +64,13 @@ public class AsyncLoadBalancerAutoConfiguration {
 	static class LoadBalancerInterceptorConfig {
 
 		@Bean
-		public AsyncLoadBalancerInterceptor asyncLoadBalancerInterceptor(
+		AsyncLoadBalancerInterceptor asyncLoadBalancerInterceptor(
 				LoadBalancerClient loadBalancerClient) {
 			return new AsyncLoadBalancerInterceptor(loadBalancerClient);
 		}
 
 		@Bean
-		public AsyncRestTemplateCustomizer asyncRestTemplateCustomizer(
+		AsyncRestTemplateCustomizer asyncRestTemplateCustomizer(
 				final AsyncLoadBalancerInterceptor loadBalancerInterceptor) {
 			return restTemplate -> {
 				List<AsyncClientHttpRequestInterceptor> list = new ArrayList<>(

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
@@ -59,7 +59,7 @@ public class LoadBalancerAutoConfiguration {
 	private List<LoadBalancerRequestTransformer> transformers = Collections.emptyList();
 
 	@Bean
-	public SmartInitializingSingleton loadBalancedRestTemplateInitializerDeprecated(
+	SmartInitializingSingleton loadBalancedRestTemplateInitializerDeprecated(
 			final ObjectProvider<List<RestTemplateCustomizer>> restTemplateCustomizers) {
 		return () -> restTemplateCustomizers.ifAvailable(customizers -> {
 			for (RestTemplate restTemplate : LoadBalancerAutoConfiguration.this.restTemplates) {
@@ -72,7 +72,7 @@ public class LoadBalancerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public LoadBalancerRequestFactory loadBalancerRequestFactory(
+	LoadBalancerRequestFactory loadBalancerRequestFactory(
 			LoadBalancerClient loadBalancerClient) {
 		return new LoadBalancerRequestFactory(loadBalancerClient, this.transformers);
 	}
@@ -82,7 +82,7 @@ public class LoadBalancerAutoConfiguration {
 	static class LoadBalancerInterceptorConfig {
 
 		@Bean
-		public LoadBalancerInterceptor loadBalancerInterceptor(
+		LoadBalancerInterceptor loadBalancerInterceptor(
 				LoadBalancerClient loadBalancerClient,
 				LoadBalancerRequestFactory requestFactory) {
 			return new LoadBalancerInterceptor(loadBalancerClient, requestFactory);
@@ -90,7 +90,7 @@ public class LoadBalancerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public RestTemplateCustomizer restTemplateCustomizer(
+		RestTemplateCustomizer restTemplateCustomizer(
 				final LoadBalancerInterceptor loadBalancerInterceptor) {
 			return restTemplate -> {
 				List<ClientHttpRequestInterceptor> list = new ArrayList<>(
@@ -111,7 +111,7 @@ public class LoadBalancerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public LoadBalancedRetryFactory loadBalancedRetryFactory() {
+		LoadBalancedRetryFactory loadBalancedRetryFactory() {
 			return new LoadBalancedRetryFactory() {
 			};
 		}
@@ -128,7 +128,7 @@ public class LoadBalancerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public RetryLoadBalancerInterceptor loadBalancerInterceptor(
+		RetryLoadBalancerInterceptor loadBalancerInterceptor(
 				LoadBalancerClient loadBalancerClient,
 				LoadBalancerRetryProperties retryProperties,
 				LoadBalancerRequestFactory requestFactory,
@@ -142,7 +142,7 @@ public class LoadBalancerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public RestTemplateCustomizer restTemplateCustomizer(
+		RestTemplateCustomizer restTemplateCustomizer(
 				final RetryLoadBalancerInterceptor loadBalancerInterceptor) {
 			return restTemplate -> {
 				List<ClientHttpRequestInterceptor> list = new ArrayList<>(

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerBeanPostProcessorAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerBeanPostProcessorAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class LoadBalancerBeanPostProcessorAutoConfiguration {
 
 	@Bean
-	public LoadBalancerWebClientBuilderBeanPostProcessor loadBalancerWebClientBuilderBeanPostProcessor(
+	LoadBalancerWebClientBuilderBeanPostProcessor loadBalancerWebClientBuilderBeanPostProcessor(
 			DeferringLoadBalancerExchangeFilterFunction deferringExchangeFilterFunction,
 			ApplicationContext context) {
 		return new LoadBalancerWebClientBuilderBeanPostProcessor(

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfiguration.java
@@ -39,7 +39,7 @@ public class ReactorLoadBalancerClientAutoConfiguration {
 
 	@ConditionalOnMissingBean
 	@Bean
-	public ReactorLoadBalancerExchangeFilterFunction loadBalancerExchangeFilterFunction(
+	ReactorLoadBalancerExchangeFilterFunction loadBalancerExchangeFilterFunction(
 			ReactiveLoadBalancer.Factory loadBalancerFactory,
 			LoadBalancerProperties properties) {
 		return new ReactorLoadBalancerExchangeFilterFunction(loadBalancerFactory,

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/ServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/serviceregistry/ServiceRegistryAutoConfiguration.java
@@ -40,7 +40,7 @@ public class ServiceRegistryAutoConfiguration {
 
 		@Bean
 		@ConditionalOnAvailableEndpoint
-		public ServiceRegistryEndpoint serviceRegistryEndpoint(
+		ServiceRegistryEndpoint serviceRegistryEndpoint(
 				ServiceRegistry serviceRegistry) {
 			ServiceRegistryEndpoint endpoint = new ServiceRegistryEndpoint(
 					serviceRegistry);

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/httpclient/HttpClientConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/httpclient/HttpClientConfiguration.java
@@ -40,19 +40,19 @@ public class HttpClientConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public ApacheHttpClientConnectionManagerFactory connManFactory() {
+		ApacheHttpClientConnectionManagerFactory connManFactory() {
 			return new DefaultApacheHttpClientConnectionManagerFactory();
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		public HttpClientBuilder apacheHttpClientBuilder() {
+		HttpClientBuilder apacheHttpClientBuilder() {
 			return HttpClientBuilder.create();
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		public ApacheHttpClientFactory apacheHttpClientFactory(
+		ApacheHttpClientFactory apacheHttpClientFactory(
 				HttpClientBuilder builder) {
 			return new DefaultApacheHttpClientFactory(builder);
 		}
@@ -67,19 +67,19 @@ public class HttpClientConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public OkHttpClientConnectionPoolFactory connPoolFactory() {
+		OkHttpClientConnectionPoolFactory connPoolFactory() {
 			return new DefaultOkHttpClientConnectionPoolFactory();
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		public OkHttpClient.Builder okHttpClientBuilder() {
+		OkHttpClient.Builder okHttpClientBuilder() {
 			return new OkHttpClient.Builder();
 		}
 
 		@Bean
 		@ConditionalOnMissingBean
-		public OkHttpClientFactory okHttpClientFactory(OkHttpClient.Builder builder) {
+		OkHttpClientFactory okHttpClientFactory(OkHttpClient.Builder builder) {
 			return new DefaultOkHttpClientFactory(builder);
 		}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/UtilAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/UtilAutoConfiguration.java
@@ -33,13 +33,13 @@ import org.springframework.context.annotation.Configuration;
 public class UtilAutoConfiguration {
 
 	@Bean
-	public InetUtilsProperties inetUtilsProperties() {
+	InetUtilsProperties inetUtilsProperties() {
 		return new InetUtilsProperties();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public InetUtils inetUtils(InetUtilsProperties properties) {
+	InetUtils inetUtils(InetUtilsProperties properties) {
 		return new InetUtils(properties);
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/actuator/FeaturesEndpointTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/actuator/FeaturesEndpointTests.java
@@ -95,7 +95,7 @@ public class FeaturesEndpointTests {
 		private List<HasFeatures> hasFeatures = new ArrayList<>();
 
 		@Bean
-		public FeaturesEndpoint cloudEndpoint() {
+		FeaturesEndpoint cloudEndpoint() {
 			return new FeaturesEndpoint(this.hasFeatures);
 		}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientAutoConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientAutoConfigurationTests.java
@@ -69,7 +69,7 @@ public class CompositeDiscoveryClientAutoConfigurationTests {
 	public static class Config {
 
 		@Bean
-		public DiscoveryClient customDiscoveryClient1() {
+		DiscoveryClient customDiscoveryClient1() {
 			return new DiscoveryClient() {
 				@Override
 				public String description() {

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientTestsConfig.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/CompositeDiscoveryClientTestsConfig.java
@@ -44,17 +44,17 @@ public class CompositeDiscoveryClientTestsConfig {
 	static final String CUSTOM_SERVICE_ID = "custom";
 
 	@Bean
-	public DiscoveryClient customDiscoveryClient() {
+	DiscoveryClient customDiscoveryClient() {
 		return aDiscoveryClient(-1, CUSTOM_DISCOVERY_CLIENT);
 	}
 
 	@Bean
-	public DiscoveryClient thirdOrderCustomDiscoveryClient() {
+	DiscoveryClient thirdOrderCustomDiscoveryClient() {
 		return aDiscoveryClient(3, FOURTH_DISCOVERY_CLIENT);
 	}
 
 	@Bean
-	public DiscoveryClient defaultOrderDiscoveryClient() {
+	DiscoveryClient defaultOrderDiscoveryClient() {
 		return aDiscoveryClient(null, DEFAULT_ORDER_DISCOVERY_CLIENT);
 	}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorTests.java
@@ -92,7 +92,7 @@ public class DiscoveryClientHealthIndicatorTests {
 	public static class Config {
 
 		@Bean
-		public DiscoveryClient discoveryClient() {
+		DiscoveryClient discoveryClient() {
 			DiscoveryClient mock = mock(DiscoveryClient.class);
 			given(mock.description()).willReturn("TestDiscoveryClient");
 			given(mock.getServices()).willReturn(Arrays.asList("TestService1"));
@@ -100,7 +100,7 @@ public class DiscoveryClientHealthIndicatorTests {
 		}
 
 		@Bean
-		public DiscoveryHealthIndicator discoveryHealthIndicator() {
+		DiscoveryHealthIndicator discoveryHealthIndicator() {
 			return new DiscoveryHealthIndicator() {
 
 				@Override

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/hypermedia/CloudHypermediaAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/hypermedia/CloudHypermediaAutoConfigurationIntegrationTests.java
@@ -98,7 +98,7 @@ public class CloudHypermediaAutoConfigurationIntegrationTests {
 	static class ConfigWithRemoteResource {
 
 		@Bean
-		public RemoteResource resource() {
+		RemoteResource resource() {
 
 			ServiceInstanceProvider provider = new StaticServiceInstanceProvider(
 					new DefaultServiceInstance("instance", "service", "localhost", 80,

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/LoadBalancerRequestFactoryConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/LoadBalancerRequestFactoryConfigurationTests.java
@@ -141,7 +141,7 @@ public class LoadBalancerRequestFactoryConfigurationTests {
 	static class Transformer {
 
 		@Bean
-		public LoadBalancerRequestTransformer transformer() {
+		LoadBalancerRequestTransformer transformer() {
 			return mock(LoadBalancerRequestTransformer.class);
 		}
 
@@ -153,7 +153,7 @@ public class LoadBalancerRequestFactoryConfigurationTests {
 
 		@Bean
 		@Order(LoadBalancerRequestTransformer.DEFAULT_ORDER + 1)
-		public LoadBalancerRequestTransformer transformer2() {
+		LoadBalancerRequestTransformer transformer2() {
 			return mock(LoadBalancerRequestTransformer.class);
 		}
 
@@ -163,7 +163,7 @@ public class LoadBalancerRequestFactoryConfigurationTests {
 	static class NoTransformer {
 
 		@Bean
-		public LoadBalancerClient loadBalancerClient() {
+		LoadBalancerClient loadBalancerClient() {
 			return mock(LoadBalancerClient.class);
 		}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
@@ -50,7 +50,7 @@ import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.Response;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -164,12 +164,12 @@ class ReactorLoadBalancerExchangeFilterFunctionTests {
 	@RestController
 	static class Config {
 
-		@RequestMapping("/hello")
+		@GetMapping("/hello")
 		public String hello() {
 			return "Hello World";
 		}
 
-		@RequestMapping("/callback")
+		@GetMapping("/callback")
 		String callbackTestResult() {
 			return "callbackTestResult";
 		}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationMgmtDisabledTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationMgmtDisabledTests.java
@@ -57,7 +57,7 @@ public class AbstractAutoServiceRegistrationMgmtDisabledTests {
 	public static class Config {
 
 		@Bean
-		public TestAutoServiceRegistration testAutoServiceRegistration(
+		TestAutoServiceRegistration testAutoServiceRegistration(
 				AutoServiceRegistrationProperties properties) {
 			return new TestAutoServiceRegistration(properties);
 		}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AbstractAutoServiceRegistrationTests.java
@@ -97,17 +97,17 @@ public class AbstractAutoServiceRegistrationTests {
 	public static class Config {
 
 		@Bean
-		public TestAutoServiceRegistration testAutoServiceRegistration() {
+		TestAutoServiceRegistration testAutoServiceRegistration() {
 			return new TestAutoServiceRegistration();
 		}
 
 		@Bean
-		public PreEventListener preRegisterListener() {
+		PreEventListener preRegisterListener() {
 			return new PreEventListener();
 		}
 
 		@Bean
-		public PostEventListener postEventListener() {
+		PostEventListener postEventListener() {
 			return new PostEventListener();
 		}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationAutoConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/serviceregistry/AutoServiceRegistrationAutoConfigurationTests.java
@@ -98,7 +98,7 @@ public class AutoServiceRegistrationAutoConfigurationTests {
 	static class HasAutoServiceRegistrationConfiguration {
 
 		@Bean
-		public AutoServiceRegistration autoServiceRegistration() {
+		AutoServiceRegistration autoServiceRegistration() {
 			return new AutoServiceRegistration() {
 			};
 		}

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomHttpClientBuilderConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomHttpClientBuilderConfigurationTests.java
@@ -63,7 +63,7 @@ class CustomHttpClientBuilderApplication {
 	static class MyConfig {
 
 		@Bean
-		public MyHttpClientBuilder builder() {
+		MyHttpClientBuilder builder() {
 			return new MyHttpClientBuilder();
 		}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomHttpClientConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomHttpClientConfigurationTests.java
@@ -100,22 +100,22 @@ class CustomApplication {
 	static class MyConfig {
 
 		@Bean
-		public ApacheHttpClientFactory clientFactory() {
+		ApacheHttpClientFactory clientFactory() {
 			return new MyApacheHttpClientFactory();
 		}
 
 		@Bean
-		public ApacheHttpClientConnectionManagerFactory connectionManagerFactory() {
+		ApacheHttpClientConnectionManagerFactory connectionManagerFactory() {
 			return new MyApacheHttpClientConnectionManagerFactory();
 		}
 
 		@Bean
-		public OkHttpClientConnectionPoolFactory connectionPoolFactory() {
+		OkHttpClientConnectionPoolFactory connectionPoolFactory() {
 			return new MyOkHttpConnectionPoolFactory();
 		}
 
 		@Bean
-		public OkHttpClientFactory okHttpClientFactory() {
+		OkHttpClientFactory okHttpClientFactory() {
 			return new MyOkHttpClientFactory();
 		}
 

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomOkHttpClientBuilderConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/commons/httpclient/CustomOkHttpClientBuilderConfigurationTests.java
@@ -72,7 +72,7 @@ class CustomOkHttpClientBuilderApplication {
 	static class MyConfig {
 
 		@Bean
-		public OkHttpClient.Builder builder() {
+		OkHttpClient.Builder builder() {
 			return new OkHttpClient.Builder().connectTimeout(1, TimeUnit.MILLISECONDS);
 		}
 

--- a/spring-cloud-context-integration-tests/src/test/java/org/springframework/cloud/context/integration/RefreshScopeIntegrationTests.java
+++ b/spring-cloud-context-integration-tests/src/test/java/org/springframework/cloud/context/integration/RefreshScopeIntegrationTests.java
@@ -228,7 +228,7 @@ public class RefreshScopeIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage(this.properties.getMessage());
 			service.setDelay(this.properties.getDelay());

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/ConfigurationPropertiesRebinderAutoConfiguration.java
@@ -47,13 +47,13 @@ public class ConfigurationPropertiesRebinderAutoConfiguration
 
 	@Bean
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
-	public static ConfigurationPropertiesBeans configurationPropertiesBeans() {
+	static ConfigurationPropertiesBeans configurationPropertiesBeans() {
 		return new ConfigurationPropertiesBeans();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
-	public ConfigurationPropertiesRebinder configurationPropertiesRebinder(
+	ConfigurationPropertiesRebinder configurationPropertiesRebinder(
 			ConfigurationPropertiesBeans beans) {
 		ConfigurationPropertiesRebinder rebinder = new ConfigurationPropertiesRebinder(
 				beans);

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/LifecycleMvcEndpointAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/LifecycleMvcEndpointAutoConfiguration.java
@@ -38,7 +38,7 @@ public class LifecycleMvcEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public EnvironmentManager environmentManager(ConfigurableEnvironment environment) {
+	EnvironmentManager environmentManager(ConfigurableEnvironment environment) {
 		return new EnvironmentManager(environment);
 	}
 

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
@@ -88,20 +88,20 @@ public class RefreshAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(RefreshScope.class)
-	public static RefreshScope refreshScope() {
+	static RefreshScope refreshScope() {
 		return new RefreshScope();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public static LoggingRebinder loggingRebinder() {
+	static LoggingRebinder loggingRebinder() {
 		return new LoggingRebinder();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBootstrapEnabled
-	public LegacyContextRefresher legacyContextRefresher(
+	LegacyContextRefresher legacyContextRefresher(
 			ConfigurableApplicationContext context, RefreshScope scope) {
 		return new LegacyContextRefresher(context, scope);
 	}
@@ -109,13 +109,13 @@ public class RefreshAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBootstrapDisabled
-	public ConfigDataContextRefresher configDataContextRefresher(
+	ConfigDataContextRefresher configDataContextRefresher(
 			ConfigurableApplicationContext context, RefreshScope scope) {
 		return new ConfigDataContextRefresher(context, scope);
 	}
 
 	@Bean
-	public RefreshEventListener refreshEventListener(ContextRefresher contextRefresher) {
+	RefreshEventListener refreshEventListener(ContextRefresher contextRefresher) {
 		return new RefreshEventListener(contextRefresher);
 	}
 

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshEndpointAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshEndpointAutoConfiguration.java
@@ -68,7 +68,7 @@ public class RefreshEndpointAutoConfiguration {
 		@ConditionalOnBean(ContextRefresher.class)
 		@ConditionalOnAvailableEndpoint
 		@ConditionalOnMissingBean
-		public RefreshEndpoint refreshEndpoint(ContextRefresher contextRefresher) {
+		RefreshEndpoint refreshEndpoint(ContextRefresher contextRefresher) {
 			return new RefreshEndpoint(contextRefresher);
 		}
 
@@ -86,7 +86,7 @@ class RestartEndpointWithIntegrationConfiguration {
 	@Bean
 	@ConditionalOnAvailableEndpoint
 	@ConditionalOnMissingBean
-	public RestartEndpoint restartEndpoint() {
+	RestartEndpoint restartEndpoint() {
 		RestartEndpoint endpoint = new RestartEndpoint();
 		if (this.exporter != null) {
 			endpoint.setIntegrationMBeanExporter(this.exporter);
@@ -103,7 +103,7 @@ class RestartEndpointWithoutIntegrationConfiguration {
 	@Bean
 	@ConditionalOnAvailableEndpoint
 	@ConditionalOnMissingBean
-	public RestartEndpoint restartEndpointWithoutIntegration() {
+	RestartEndpoint restartEndpointWithoutIntegration() {
 		return new RestartEndpoint();
 	}
 
@@ -116,7 +116,7 @@ class PauseResumeEndpointsConfiguration {
 	@ConditionalOnBean(RestartEndpoint.class)
 	@ConditionalOnMissingBean
 	@ConditionalOnAvailableEndpoint
-	public RestartEndpoint.PauseEndpoint pauseEndpoint(RestartEndpoint restartEndpoint) {
+	RestartEndpoint.PauseEndpoint pauseEndpoint(RestartEndpoint restartEndpoint) {
 		return restartEndpoint.getPauseEndpoint();
 	}
 
@@ -124,7 +124,7 @@ class PauseResumeEndpointsConfiguration {
 	@ConditionalOnBean(RestartEndpoint.class)
 	@ConditionalOnMissingBean
 	@ConditionalOnAvailableEndpoint
-	public RestartEndpoint.ResumeEndpoint resumeEndpoint(
+	RestartEndpoint.ResumeEndpoint resumeEndpoint(
 			RestartEndpoint restartEndpoint) {
 		return restartEndpoint.getResumeEndpoint();
 	}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/WritableEnvironmentEndpointAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/WritableEnvironmentEndpointAutoConfiguration.java
@@ -61,7 +61,7 @@ public class WritableEnvironmentEndpointAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnAvailableEndpoint
-	public WritableEnvironmentEndpoint writableEnvironmentEndpoint(
+	WritableEnvironmentEndpoint writableEnvironmentEndpoint(
 			Environment environment) {
 		WritableEnvironmentEndpoint endpoint = new WritableEnvironmentEndpoint(
 				environment);
@@ -74,7 +74,7 @@ public class WritableEnvironmentEndpointAutoConfiguration {
 
 	@Bean
 	@ConditionalOnAvailableEndpoint
-	public WritableEnvironmentEndpointWebExtension writableEnvironmentEndpointWebExtension(
+	WritableEnvironmentEndpointWebExtension writableEnvironmentEndpointWebExtension(
 			WritableEnvironmentEndpoint endpoint, EnvironmentManager environment) {
 		return new WritableEnvironmentEndpointWebExtension(endpoint, environment);
 	}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/EncryptionBootstrapConfiguration.java
@@ -52,7 +52,7 @@ public class EncryptionBootstrapConfiguration {
 	private KeyProperties key;
 
 	@Bean
-	public EnvironmentDecryptApplicationInitializer environmentDecryptApplicationListener() {
+	EnvironmentDecryptApplicationInitializer environmentDecryptApplicationListener() {
 		if (this.encryptor == null) {
 			this.encryptor = new FailsafeTextEncryptor();
 		}
@@ -76,7 +76,7 @@ public class EncryptionBootstrapConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(TextEncryptor.class)
-		public TextEncryptor textEncryptor() {
+		TextEncryptor textEncryptor() {
 			KeyStore keyStore = this.key.getKeyStore();
 			if (keyStore.getLocation() != null) {
 				if (keyStore.getLocation().exists()) {
@@ -107,7 +107,7 @@ public class EncryptionBootstrapConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(TextEncryptor.class)
-		public TextEncryptor textEncryptor() {
+		TextEncryptor textEncryptor() {
 			return new EncryptorFactory(this.key.getSalt()).create(this.key.getKey());
 		}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/TestBootstrapConfiguration.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/TestBootstrapConfiguration.java
@@ -48,7 +48,7 @@ public class TestBootstrapConfiguration {
 
 	@Bean
 	@Qualifier("foo-during-bootstrap")
-	public String fooDuringBootstrap(ConfigurableEnvironment environment,
+	String fooDuringBootstrap(ConfigurableEnvironment environment,
 			ApplicationEventPublisher publisher) {
 		String property = environment.getProperty("test.bootstrap.foo", "undefined");
 
@@ -60,7 +60,7 @@ public class TestBootstrapConfiguration {
 	}
 
 	@Bean
-	public ApplicationContextInitializer<ConfigurableApplicationContext> customInitializer() {
+	ApplicationContextInitializer<ConfigurableApplicationContext> customInitializer() {
 		return new ApplicationContextInitializer<ConfigurableApplicationContext>() {
 
 			@Override

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/config/BootstrapListenerHierarchyIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/config/BootstrapListenerHierarchyIntegrationTests.java
@@ -97,7 +97,7 @@ public class BootstrapListenerHierarchyIntegrationTests {
 	static class RootConfiguration {
 
 		@Bean
-		public String rootBean() {
+		String rootBean() {
 			return "rootBean";
 		}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderIntegrationTests.java
@@ -130,7 +130,7 @@ public class ConfigurationPropertiesRebinderIntegrationTests {
 		// exposes https://github.com/spring-cloud/spring-cloud-commons/issues/337
 		@Bean
 		@ConfigurationProperties("some.service")
-		public SomeService someService() {
+		SomeService someService() {
 			return ProxyFactory.getProxy(SomeService.class,
 					(MethodInterceptor) methodInvocation -> null);
 		}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/MoreRefreshScopeIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/MoreRefreshScopeIntegrationTests.java
@@ -197,7 +197,7 @@ public class MoreRefreshScopeIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public TestService service() {
+		TestService service() {
 			TestService service = new TestService();
 			service.setMessage(properties().getMessage());
 			service.setDelay(properties().getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshEndpointIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshEndpointIntegrationTests.java
@@ -40,7 +40,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -98,7 +98,7 @@ public class RefreshEndpointIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public Controller controller() {
+		Controller controller() {
 			return new Controller();
 		}
 
@@ -114,7 +114,7 @@ public class RefreshEndpointIntegrationTests {
 			this.message = message;
 		}
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public String hello() {
 			return this.message;
 		}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConcurrencyTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConcurrencyTests.java
@@ -161,7 +161,7 @@ public class RefreshScopeConcurrencyTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage(this.properties.getMessage());
 			service.setDelay(this.properties.getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConfigurationScaleTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConfigurationScaleTests.java
@@ -177,13 +177,13 @@ public class RefreshScopeConfigurationScaleTests {
 
 		@Bean
 		@RefreshScope
-		public TestProperties properties() {
+		TestProperties properties() {
 			return new TestProperties();
 		}
 
 		@Bean
 		@RefreshScope
-		public ExampleService service(TestProperties properties) {
+		ExampleService service(TestProperties properties) {
 			ExampleService service = new ExampleService();
 			service.setMessage(properties.getMessage());
 			service.setDelay(properties.getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeConfigurationTests.java
@@ -32,7 +32,7 @@ import org.springframework.cloud.context.scope.refresh.RefreshScopeConfiguration
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -124,7 +124,7 @@ public class RefreshScopeConfigurationTests {
 			@Value("${message:Hello World!}")
 			String message;
 
-			@RequestMapping("/")
+			@GetMapping("/")
 			public String hello() {
 				return this.message;
 			}
@@ -144,7 +144,7 @@ public class RefreshScopeConfigurationTests {
 			SpringApplication.run(Application.class, args);
 		}
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public String hello() {
 			return this.message;
 		}
@@ -160,7 +160,7 @@ public class RefreshScopeConfigurationTests {
 
 		@Bean
 		@RefreshScope
-		public Controller controller() {
+		Controller controller() {
 			return new Controller();
 		}
 
@@ -172,7 +172,7 @@ public class RefreshScopeConfigurationTests {
 		@Value("${message:Hello World!}")
 		String message;
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		// Deliberately use package scope
 		String hello() {
 			return this.message;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeIntegrationTests.java
@@ -226,7 +226,7 @@ public class RefreshScopeIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage(this.properties.getMessage());
 			service.setDelay(this.properties.getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeLazyIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeLazyIntegrationTests.java
@@ -209,7 +209,7 @@ public class RefreshScopeLazyIntegrationTests {
 		private TestProperties properties;
 
 		@Bean
-		public static org.springframework.cloud.context.scope.refresh.RefreshScope refreshScope() {
+		static org.springframework.cloud.context.scope.refresh.RefreshScope refreshScope() {
 			org.springframework.cloud.context.scope.refresh.RefreshScope scope = null;
 			scope = new org.springframework.cloud.context.scope.refresh.RefreshScope();
 			scope.setEager(false);
@@ -218,7 +218,7 @@ public class RefreshScopeLazyIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage(this.properties.getMessage());
 			service.setDelay(this.properties.getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeNullBeanIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeNullBeanIntegrationTests.java
@@ -71,7 +71,7 @@ public class RefreshScopeNullBeanIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public OptionalService service() {
+		OptionalService service() {
 			return null;
 		}
 
@@ -86,7 +86,7 @@ public class RefreshScopeNullBeanIntegrationTests {
 		private OptionalService optionalService;
 
 		@Bean
-		public MyCustomComponent myCustomComponent() {
+		MyCustomComponent myCustomComponent() {
 			return new MyCustomComponent(this.optionalService);
 		}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopePureScaleTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopePureScaleTests.java
@@ -165,7 +165,7 @@ public class RefreshScopePureScaleTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage("Foo");
 			return service;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeScaleTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeScaleTests.java
@@ -164,7 +164,7 @@ public class RefreshScopeScaleTests {
 
 		@Bean
 		@RefreshScope
-		public ExampleService service() {
+		ExampleService service() {
 			ExampleService service = new ExampleService();
 			service.setMessage(this.properties.getMessage());
 			service.setDelay(this.properties.getDelay());

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeSerializationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeSerializationTests.java
@@ -62,13 +62,13 @@ public class RefreshScopeSerializationTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public RefreshScope refreshScope() {
+		RefreshScope refreshScope() {
 			return new RefreshScope();
 		}
 
 		@Bean
 		@org.springframework.cloud.context.config.annotation.RefreshScope
-		public TestBean testBean() {
+		TestBean testBean() {
 			return new TestBean();
 		}
 

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeWebIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/refresh/RefreshScopeWebIntegrationTests.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.context.scope.refresh.RefreshScopeWebIntegratio
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -81,7 +81,7 @@ public class RefreshScopeWebIntegrationTests {
 
 		@Bean
 		@RefreshScope
-		public Client application() {
+		Client application() {
 			return new Client();
 		}
 
@@ -93,7 +93,7 @@ public class RefreshScopeWebIntegrationTests {
 		@Value("${message:Hello World!}")
 		String message;
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public String hello() {
 			return this.message;
 		}

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
@@ -48,7 +48,7 @@ public class LoadBalancerClientConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ReactorLoadBalancer<ServiceInstance> reactorServiceInstanceLoadBalancer(
+	ReactorLoadBalancer<ServiceInstance> reactorServiceInstanceLoadBalancer(
 			Environment environment,
 			LoadBalancerClientFactory loadBalancerClientFactory) {
 		String name = environment.getProperty(LoadBalancerClientFactory.PROPERTY_NAME);
@@ -66,7 +66,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "default", matchIfMissing = true)
-		public ServiceInstanceListSupplier discoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier discoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withDiscoveryClient()
 					.withCaching().build(context);
@@ -77,7 +77,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "zone-preference")
-		public ServiceInstanceListSupplier zonePreferenceDiscoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier zonePreferenceDiscoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withDiscoveryClient()
 					.withZonePreference().withCaching().build(context);
@@ -88,7 +88,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "health-check")
-		public ServiceInstanceListSupplier healthCheckDiscoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier healthCheckDiscoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withDiscoveryClient()
 					.withHealthChecks().withCaching().build(context);
@@ -106,7 +106,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "default", matchIfMissing = true)
-		public ServiceInstanceListSupplier discoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier discoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withBlockingDiscoveryClient()
 					.withCaching().build(context);
@@ -117,7 +117,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "zone-preference")
-		public ServiceInstanceListSupplier zonePreferenceDiscoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier zonePreferenceDiscoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withBlockingDiscoveryClient()
 					.withZonePreference().withCaching().build(context);
@@ -128,7 +128,7 @@ public class LoadBalancerClientConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.configurations",
 				havingValue = "health-check")
-		public ServiceInstanceListSupplier healthCheckDiscoveryClientServiceInstanceListSupplier(
+		ServiceInstanceListSupplier healthCheckDiscoveryClientServiceInstanceListSupplier(
 				ConfigurableApplicationContext context) {
 			return ServiceInstanceListSupplier.builder().withBlockingDiscoveryClient()
 					.withHealthChecks().withCaching().build(context);

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/BlockingLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/BlockingLoadBalancerClientAutoConfiguration.java
@@ -49,7 +49,7 @@ public class BlockingLoadBalancerClientAutoConfiguration {
 	@Bean
 	@ConditionalOnBean(LoadBalancerClientFactory.class)
 	@ConditionalOnMissingBean
-	public LoadBalancerClient blockingLoadBalancerClient(
+	LoadBalancerClient blockingLoadBalancerClient(
 			LoadBalancerClientFactory loadBalancerClientFactory,
 			LoadBalancerProperties properties) {
 		return new BlockingLoadBalancerClient(loadBalancerClientFactory, properties);

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/LoadBalancerAutoConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/LoadBalancerAutoConfiguration.java
@@ -53,14 +53,14 @@ public class LoadBalancerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public LoadBalancerZoneConfig zoneConfig(Environment environment) {
+	LoadBalancerZoneConfig zoneConfig(Environment environment) {
 		return new LoadBalancerZoneConfig(
 				environment.getProperty("spring.cloud.loadbalancer.zone"));
 	}
 
 	@ConditionalOnMissingBean
 	@Bean
-	public LoadBalancerClientFactory loadBalancerClientFactory() {
+	LoadBalancerClientFactory loadBalancerClientFactory() {
 		LoadBalancerClientFactory clientFactory = new LoadBalancerClientFactory();
 		clientFactory.setConfigurations(
 				this.configurations.getIfAvailable(Collections::emptyList));

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/CachingServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/CachingServiceInstanceListSupplierTests.java
@@ -77,7 +77,7 @@ class CachingServiceInstanceListSupplierTests {
 	protected static class TestConfig {
 
 		@Bean
-		public ReactiveDiscoveryClient reactiveDiscoveryClient() {
+		ReactiveDiscoveryClient reactiveDiscoveryClient() {
 			return new ReactiveDiscoveryClient() {
 				@Override
 				public String description() {
@@ -116,12 +116,12 @@ class CachingServiceInstanceListSupplierTests {
 		}
 
 		@Bean
-		public LoadBalancerProperties loadBalancerProperties() {
+		LoadBalancerProperties loadBalancerProperties() {
 			return new LoadBalancerProperties();
 		}
 
 		@Bean
-		public WebClient.Builder webClientBuilder() {
+		WebClient.Builder webClientBuilder() {
 			return WebClient.builder();
 		}
 

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/LoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/LoadBalancerTests.java
@@ -190,7 +190,7 @@ public class LoadBalancerTests {
 	protected static class MyServiceConfig {
 
 		@Bean
-		public RoundRobinLoadBalancer roundRobinContextLoadBalancer(
+		RoundRobinLoadBalancer roundRobinContextLoadBalancer(
 				LoadBalancerClientFactory clientFactory, Environment env) {
 			String serviceId = clientFactory.getName(env);
 			return new RoundRobinLoadBalancer(clientFactory.getLazyProvider(serviceId,

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilderTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilderTests.java
@@ -89,7 +89,7 @@ public class ServiceInstanceListSupplierBuilderTests {
 	private static class CacheTestConfig {
 
 		@Bean
-		public LoadBalancerCacheManager cacheManager() {
+		LoadBalancerCacheManager cacheManager() {
 			return mock(LoadBalancerCacheManager.class);
 		}
 
@@ -98,17 +98,17 @@ public class ServiceInstanceListSupplierBuilderTests {
 	private static class BaseTestConfig {
 
 		@Bean
-		public ReactiveDiscoveryClient reactiveDiscoveryClient() {
+		ReactiveDiscoveryClient reactiveDiscoveryClient() {
 			return mock(ReactiveDiscoveryClient.class);
 		}
 
 		@Bean
-		public LoadBalancerProperties loadBalancerProperties() {
+		LoadBalancerProperties loadBalancerProperties() {
 			return new LoadBalancerProperties();
 		}
 
 		@Bean
-		public WebClient.Builder webClientBuilder() {
+		WebClient.Builder webClientBuilder() {
 			return WebClient.builder();
 		}
 


### PR DESCRIPTION
This demonstrates some simple Spring hygiene recipes, reducing unnecessary public visibility modifiers and replacing the CSRF-injection vulnerable `@RequestMapping` with `@GetMapping`.