### PR TITLE
remove useless code

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/refresh/RefreshScope.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/refresh/RefreshScope.java
@@ -125,9 +125,6 @@ public class RefreshScope extends GenericScope implements ApplicationContextAwar
 			if (this.getName().equals(definition.getScope())
 					&& !definition.isLazyInit()) {
 				Object bean = this.context.getBean(name);
-				if (bean != null) {
-					bean.getClass();
-				}
 			}
 		}
 	}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/refresh/RefreshScope.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/refresh/RefreshScope.java
@@ -124,7 +124,7 @@ public class RefreshScope extends GenericScope implements ApplicationContextAwar
 			BeanDefinition definition = this.registry.getBeanDefinition(name);
 			if (this.getName().equals(definition.getScope())
 					&& !definition.isLazyInit()) {
-				Object bean = this.context.getBean(name);
+				 this.context.getBean(name);
 			}
 		}
 	}


### PR DESCRIPTION
we don't need bean.getClass(). in the this.context.getBean(name) method already get the bean runtime class.