### PR TITLE
Fix bug of service instance refetching when repeating health check is activated

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplier.java
@@ -43,6 +43,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * @author Olga Maciaszek-Sharma
  * @author Roman Matiushchenko
+ * @author Roman Chigvintsev
  * @since 2.2.0
  */
 public class HealthCheckServiceInstanceListSupplier
@@ -73,9 +74,9 @@ public class HealthCheckServiceInstanceListSupplier
 				.onlyIf(repeatContext -> this.healthCheck.getRefetchInstances())
 				.fixedBackoff(healthCheck.getRefetchInstancesInterval());
 		Flux<List<ServiceInstance>> aliveInstancesFlux = Flux.defer(delegate)
+				.repeatWhen(aliveInstancesReplayRepeat)
 				.switchMap(serviceInstances -> healthCheckFlux(serviceInstances).map(
-						alive -> Collections.unmodifiableList(new ArrayList<>(alive))))
-				.repeatWhen(aliveInstancesReplayRepeat);
+						alive -> Collections.unmodifiableList(new ArrayList<>(alive))));
 		aliveInstancesReplay = aliveInstancesFlux
 				.delaySubscription(Duration.ofMillis(healthCheck.getInitialDelay()))
 				.replay(1).refCount(1);


### PR DESCRIPTION
Fixes gh-899

(cherry picked from commit 3d257b43003a02b64c4f7fd97680e7981d0b52f4)