### PR TITLE
Fixes gh-898

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -93,7 +93,7 @@ public class ConfigurationPropertiesRebinder
 			try {
 				Object bean = this.applicationContext.getBean(name);
 				if (AopUtils.isAopProxy(bean)) {
-					bean = ProxyUtils.getTargetObject(bean);
+					bean = ProxyUtils.getUltimateTargetObject(bean);
 				}
 				if (bean != null) {
 					// TODO: determine a more general approach to fix this.

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/util/ProxyUtils.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/util/ProxyUtils.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.util;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.util.Assert;
 
 /**
  * @author Ryan Baxter
@@ -33,6 +34,23 @@ public final class ProxyUtils {
 		try {
 			if (AopUtils.isAopProxy(candidate) && (candidate instanceof Advised)) {
 				return (T) ((Advised) candidate).getTargetSource().getTarget();
+			}
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException("Failed to unwrap proxied object", ex);
+		}
+		return (T) candidate;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getUltimateTargetObject(Object candidate) {
+		Assert.notNull(candidate, "Candidate must not be null");
+		try {
+			if (AopUtils.isAopProxy(candidate) && candidate instanceof Advised) {
+				Object target = ((Advised) candidate).getTargetSource().getTarget();
+				if (target != null) {
+					return (T) getUltimateTargetObject(target);
+				}
 			}
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
If HikariDataSource bean gets AOP-proxied more than once, the spring-cloud rebind operation doesn't treat it as never-refreshable.