### PR TITLE
Run all EnvironmentPostProcessors on refresh.

### DIFF
--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataLoader.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataLoader.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.test;
+
+import java.util.Collections;
+
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigDataLoader;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.core.env.MapPropertySource;
+
+public class TestConfigDataLoader implements ConfigDataLoader<TestConfigDataResource> {
+
+	@Override
+	public ConfigData load(ConfigDataLoaderContext context, TestConfigDataResource resource)
+			throws ConfigDataResourceNotFoundException {
+		return new ConfigData(
+				Collections.singletonList(new MapPropertySource("testconfigdatadatasource", resource.props)));
+	}
+
+}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataLocationResolver.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataLocationResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
+import org.springframework.boot.context.config.ConfigDataLocationResolver;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.boot.context.properties.bind.Bindable;
+
+public class TestConfigDataLocationResolver implements ConfigDataLocationResolver<TestConfigDataResource> {
+
+	public static AtomicInteger count = new AtomicInteger(1);
+
+	public static Map<String, Object> config = new HashMap<>();
+
+	public static Object instance;
+
+	@Override
+	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
+		return location.hasPrefix("testdatasource:");
+	}
+
+	@Override
+	public List<TestConfigDataResource> resolve(ConfigDataLocationResolverContext context, ConfigDataLocation location)
+			throws ConfigDataLocationNotFoundException, ConfigDataResourceNotFoundException {
+		if (instance != null) {
+			BootstrapRegistry.InstanceSupplier<Object> supplier = BootstrapRegistry.InstanceSupplier.of(instance);
+			Class<Object> aClass = (Class<Object>) instance.getClass();
+			context.getBootstrapContext().registerIfAbsent(aClass, supplier);
+		}
+		String myplaceholder = context.getBinder().bind("myplaceholder", Bindable.of(String.class)).orElse("notfound");
+		HashMap<String, Object> props = new HashMap<>(config);
+		props.put(TestEnvPostProcessor.EPP_VALUE, count.get());
+		if (count.get() == 99 && myplaceholder.contains("${vcap")) {
+			throw new ConfigDataResourceNotFoundException(new TestConfigDataResource(props),
+					new IllegalArgumentException("placeholder not resolved"));
+		}
+		return Collections.singletonList(new TestConfigDataResource(props));
+	}
+
+}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataResource.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestConfigDataResource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.test;
+
+import java.util.HashMap;
+import java.util.Objects;
+
+import org.springframework.boot.context.config.ConfigDataResource;
+
+public class TestConfigDataResource extends ConfigDataResource {
+
+	final HashMap<String, Object> props;
+
+	public TestConfigDataResource(HashMap<String, Object> props) {
+		this.props = props;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TestConfigDataResource that = (TestConfigDataResource) o;
+		return Objects.equals(this.props, that.props);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.props);
+	}
+
+}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestEnvPostProcessor.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/test/TestEnvPostProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+public class TestEnvPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+	public static final String EPP_ENABLED = "configdatarefresh.epp.enabled";
+
+	public static final String EPP_VALUE = "configdatarefresh.epp.count";
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		if (environment.getProperty(EPP_ENABLED, Boolean.class, false)) {
+			Map<String, Object> source = new HashMap<>();
+			source.put("spring.cloud.refresh.additional-property-sources-to-retain", getClass().getSimpleName());
+			source.put("spring.config.import", "testdatasource:");
+			MapPropertySource propertySource = new MapPropertySource(getClass().getSimpleName(), source);
+			environment.getPropertySources().addFirst(propertySource);
+		}
+	}
+
+	@Override
+	public int getOrder() {
+		return ConfigDataEnvironmentPostProcessor.ORDER - 1;
+	}
+
+}

--- a/spring-cloud-context/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-context/src/test/resources/META-INF/spring.factories
@@ -4,12 +4,12 @@ org.springframework.cloud.bootstrap.TestBootstrapConfiguration,\
 org.springframework.cloud.bootstrap.TestHigherPriorityBootstrapConfiguration
 
 org.springframework.boot.env.EnvironmentPostProcessor=\
-org.springframework.cloud.context.refresh.ConfigDataContextRefresherIntegrationTests.TestEnvPostProcessor
+org.springframework.cloud.context.test.TestEnvPostProcessor
 
 # ConfigData Location Resolvers
 org.springframework.boot.context.config.ConfigDataLocationResolver=\
-org.springframework.cloud.context.refresh.ConfigDataContextRefresherIntegrationTests.TestConfigDataLocationResolver
+org.springframework.cloud.context.test.TestConfigDataLocationResolver
 
 # ConfigData Loaders
 org.springframework.boot.context.config.ConfigDataLoader=\
-org.springframework.cloud.context.refresh.ConfigDataContextRefresherIntegrationTests.TestConfigDataLoader
+org.springframework.cloud.context.test.TestConfigDataLoader

--- a/spring-cloud-context/src/test/resources/application.properties
+++ b/spring-cloud-context/src/test/resources/application.properties
@@ -7,3 +7,4 @@ debug:true
 #logging.level.org.springframework.context.annotation: DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.com.zaxxer.hikari=ERROR
+myplaceholder=${vcap.services.myvcap.myvar}


### PR DESCRIPTION
This includes ConfigDataEnvironmentPostProcessors which replaces the static call.

Issue #968 was specifically about the cloud foundry vcap post processor. Previously the DecryptEnvironmentPostProcessor was hard coded in ConfigDataContextRefresher

Fixes gh-968