### PR TITLE
LoggingSystemShutdownListener ClassLoader

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/LoggingSystemShutdownListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/LoggingSystemShutdownListener.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.bootstrap;
 
+import java.util.Optional;
+
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.context.ApplicationListener;
@@ -42,12 +45,14 @@ public class LoggingSystemShutdownListener
 
 	@Override
 	public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
-		shutdownLogging();
+		Optional<ClassLoader> classLoader = Optional.ofNullable(event)
+				.map(ApplicationEnvironmentPreparedEvent::getSpringApplication).map(SpringApplication::getClassLoader);
+		shutdownLogging(classLoader);
 	}
 
-	private void shutdownLogging() {
+	private void shutdownLogging(Optional<ClassLoader> classLoader) {
 		// TODO: only enable if bootstrap and legacy
-		LoggingSystem loggingSystem = LoggingSystem.get(ClassUtils.getDefaultClassLoader());
+		LoggingSystem loggingSystem = LoggingSystem.get(classLoader.orElse(ClassUtils.getDefaultClassLoader()));
 		loggingSystem.cleanUp();
 		loggingSystem.beforeInitialize();
 	}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/LoggingSystemShutdownListenerTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/LoggingSystemShutdownListenerTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.bootstrap;
+
+import org.junit.Test;
+
+import org.springframework.boot.DefaultBootstrapContext;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+
+public class LoggingSystemShutdownListenerTests {
+
+	@Test
+	public void defaultClasspath() {
+		LoggingSystemShutdownListener listener = new LoggingSystemShutdownListener();
+		DefaultBootstrapContext bootstrapCtx = new DefaultBootstrapContext();
+		SpringApplication application = new SpringApplication();
+		ApplicationEnvironmentPreparedEvent event = new ApplicationEnvironmentPreparedEvent(bootstrapCtx, application,
+				null, null);
+		listener.onApplicationEvent(event);
+	}
+
+}


### PR DESCRIPTION
Use the ClassLoader from the SpringApplication if available.

This is related to https://github.com/spring-projects/spring-boot/issues/26126. If the SpringApplication is created with a different classloader that can create issues for the LoggingSystemShutdownListener since it may end up using a different classloader than the one the SpringApplication is using.