### PR TITLE
Issue-906 Adding support for query param in lb health-check

### DIFF
--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/HealthCheckServiceInstanceListSupplierTests.java
@@ -46,6 +46,7 @@ import org.springframework.cloud.loadbalancer.support.ServiceInstanceListSupplie
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -529,6 +530,22 @@ class HealthCheckServiceInstanceListSupplierTests {
 				.untilAsserted(() -> Assertions.assertThat(instancesCanceled).hasValue(1));
 	}
 
+	@SuppressWarnings("ConstantConditions")
+	@Test
+	void shouldCheckInstanceWithProvidedHealthCheckPathWithQueryParams() {
+		String serviceId = "ignored-service";
+		healthCheck.getPath().put("ignored-service", "/health?someparam=somevalue");
+		ServiceInstance serviceInstance = new DefaultServiceInstance("ignored-service-1", serviceId, "127.0.0.1", port,
+				false);
+		listSupplier = new HealthCheckServiceInstanceListSupplier(
+				ServiceInstanceListSuppliers.from(serviceId, serviceInstance), healthCheck,
+				healthCheckFunction(webClient));
+
+		boolean alive = listSupplier.isAlive(serviceInstance).block();
+
+		assertThat(alive).isTrue();
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableAutoConfiguration
 	@RestController
@@ -539,7 +556,7 @@ class HealthCheckServiceInstanceListSupplierTests {
 		}
 
 		@GetMapping("/health")
-		void healthCheck() {
+		void healthCheck(@RequestParam(value = "someparam", required = false) String param) {
 
 		}
 


### PR DESCRIPTION
This PR is to fix issue https://github.com/spring-cloud/spring-cloud-commons/issues/906
where loadbalancer healthcheck has query param and
character "?" was automatically
converted to a URI encoding %3F, causing the request to fail.

What has changed
* Using `UriComponentsBuilder.fromUriString` this method parses the string and handles url
  and query param path.