### PR TITLE
Add `with()` method to support external ServiceInstanceListSupplier(#988)

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
@@ -45,6 +45,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author Zhiguo Chen
  */
 public final class ServiceInstanceListSupplierBuilder {
 
@@ -248,6 +249,12 @@ public final class ServiceInstanceListSupplierBuilder {
 		return this;
 	}
 
+	/**
+	 * Support {@link ServiceInstanceListSupplierBuilder} can be added to the expansion implementation of
+	 * {@link ServiceInstanceListSupplier} by this method
+	 * @param delegateCreator a {@link DelegateCreator} object
+	 * @return the {@link ServiceInstanceListSupplierBuilder} object
+	 */
 	public ServiceInstanceListSupplierBuilder with(DelegateCreator delegateCreator) {
 		if (delegateCreator != null) {
 			creators.add(delegateCreator);

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
@@ -248,6 +248,13 @@ public final class ServiceInstanceListSupplierBuilder {
 		return this;
 	}
 
+	public ServiceInstanceListSupplierBuilder with(DelegateCreator delegateCreator) {
+		if (delegateCreator != null) {
+			creators.add(delegateCreator);
+		}
+		return this;
+	}
+
 	/**
 	 * Builds the {@link ServiceInstanceListSupplier} hierarchy.
 	 * @param context application context

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
@@ -251,7 +251,7 @@ public final class ServiceInstanceListSupplierBuilder {
 
 	/**
 	 * Support {@link ServiceInstanceListSupplierBuilder} can be added to the expansion implementation of
-	 * {@link ServiceInstanceListSupplier} by this method
+	 * {@link ServiceInstanceListSupplier} by this method.
 	 * @param delegateCreator a {@link DelegateCreator} object
 	 * @return the {@link ServiceInstanceListSupplierBuilder} object
 	 */


### PR DESCRIPTION
Add `with()` method to support external `ServiceInstanceListSupplier` extension(#988)