### PR TITLE
fix: remove unnecessary code

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
@@ -49,13 +49,13 @@ import org.springframework.context.event.SmartApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySource.StubPropertySource;
-import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
@@ -141,11 +141,9 @@ public class BootstrapApplicationListener implements ApplicationListener<Applica
 
 	private ConfigurableApplicationContext bootstrapServiceContext(ConfigurableEnvironment environment,
 			final SpringApplication application, String configName) {
-		StandardEnvironment bootstrapEnvironment = new StandardEnvironment();
+		ConfigurableEnvironment bootstrapEnvironment = new AbstractEnvironment() {
+		};
 		MutablePropertySources bootstrapProperties = bootstrapEnvironment.getPropertySources();
-		for (PropertySource<?> source : bootstrapProperties) {
-			bootstrapProperties.remove(source.getName());
-		}
 		String configLocation = environment.resolvePlaceholders("${spring.cloud.bootstrap.location:}");
 		String configAdditionalLocation = environment
 				.resolvePlaceholders("${spring.cloud.bootstrap.additional-location:}");

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
@@ -43,13 +43,13 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
@@ -202,10 +202,8 @@ public class PropertySourceBootstrapConfiguration
 	}
 
 	private Environment environment(MutablePropertySources incoming) {
-		StandardEnvironment environment = new StandardEnvironment();
-		for (PropertySource<?> source : environment.getPropertySources()) {
-			environment.getPropertySources().remove(source.getName());
-		}
+		ConfigurableEnvironment environment = new AbstractEnvironment() {
+		};
 		for (PropertySource<?> source : incoming) {
 			environment.getPropertySources().addLast(source);
 		}


### PR DESCRIPTION
new StandardEnvironment will add systemProperties/systemEnvironment PropertySource within its constructor which we do not need.
**we should not create object which do something we do not want, then undo it**