### PR TITLE
Code modification based on CodeGuru.

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -83,7 +83,7 @@ public class DefaultServiceInstance implements ServiceInstance {
 	 */
 	public static URI getUri(ServiceInstance instance) {
 		String scheme = (instance.isSecure()) ? "https" : "http";
-		String uri = String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort());
+		String uri = String.format("%s://%s:%d", scheme, instance.getHost(), instance.getPort());
 		return URI.create(uri);
 	}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.commons.util;
 
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.util.StringUtils;
+import lombok.NonNull;
+
 
 /**
  * @author Spencer Gibb
@@ -78,7 +80,11 @@ public final class IdUtils {
 	public static String combineParts(String firstPart, String separator, String secondPart) {
 		String combined = null;
 		if (firstPart != null && secondPart != null) {
-			combined = firstPart + separator + secondPart;
+			if (separator != null) {
+				combined = firstPart + separator + secondPart;
+			} else {
+				combined = firstPart + secondPart;
+			}
 		}
 		else if (firstPart != null) {
 			combined = firstPart;

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/IdUtils.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.commons.util;
 
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.util.StringUtils;
-import lombok.NonNull;
 
 
 /**

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
@@ -230,9 +230,10 @@ public class BootstrapApplicationListener implements ApplicationListener<Applica
 				if (target instanceof MapPropertySource && target != source && source instanceof MapPropertySource) {
 					Map<String, Object> targetMap = ((MapPropertySource) target).getSource();
 					Map<String, Object> map = ((MapPropertySource) source).getSource();
-					for (String key : map.keySet()) {
+					for (Map.Entry<String, Object> entry : map.entrySet()) {
+						String key = entry.getKey();
 						if (!target.containsProperty(key)) {
-							targetMap.put(key, map.get(key));
+							targetMap.put(key, entry.getValue());
 						}
 					}
 				}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/refresh/ContextRefresher.java
@@ -135,17 +135,21 @@ public abstract class ContextRefresher {
 
 	private Map<String, Object> changes(Map<String, Object> before, Map<String, Object> after) {
 		Map<String, Object> result = new HashMap<String, Object>();
-		for (String key : before.keySet()) {
+		for (Map.Entry<String, Object> entry : before.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
 			if (!after.containsKey(key)) {
 				result.put(key, null);
 			}
-			else if (!equal(before.get(key), after.get(key))) {
+			else if (!equal(value, after.get(key))) {
 				result.put(key, after.get(key));
 			}
 		}
-		for (String key : after.keySet()) {
+		for (Map.Entry<String, Object> entry : after.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
 			if (!before.containsKey(key)) {
-				result.put(key, after.get(key));
+				result.put(key, value);
 			}
 		}
 		return result;

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/health/RefreshScopeHealthIndicator.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/health/RefreshScopeHealthIndicator.java
@@ -58,8 +58,10 @@ public class RefreshScopeHealthIndicator extends AbstractHealthIndicator {
 					builder.withException(errors.values().iterator().next());
 				}
 				else {
-					for (String name : errors.keySet()) {
-						builder.withDetail(name, errors.get(name));
+					for (Map.Entry<String, Exception> entry : errors.entrySet()) {
+						String name = entry.getKey();
+						Exception e = entry.getValue();
+						builder.withDetail(name, e);
 					}
 				}
 			}


### PR DESCRIPTION
- Some code uses '%s' to format int: 'size' expression. Use %d, not %s, for integers. This ensures locale-sensitive formatting.
- some lines of code lack validation when processing input data.
- Iterating over map.keySet() and calling map.get(Key) to get the values within the loop is inefficient. Iterate over map.entrySet() and access the values using entry.getValue() to avoid potential performance penalty due to lookup.
