### PR TITLE
Fix is2_5 comment

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/configuration/SpringBootVersionVerifier.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/configuration/SpringBootVersionVerifier.java
@@ -105,7 +105,7 @@ class SpringBootVersionVerifier implements CompatibilityVerifier {
 			@Override
 			public boolean isCompatible() {
 				try {
-					// since 2.4
+					// since 2.5
 					Class.forName("org.springframework.boot.context.properties.bind.Bindable.BindRestriction");
 					return true;
 				}


### PR DESCRIPTION
Only for 3.0.x branch, since 3.1.x targets Spring Boot 2.6+.

```java
/**
 * Restrictions that can be applied when binding values.
 *
 * @since 2.5.0
 */
public enum BindRestriction {
```