### PR TITLE
Support uri without port for default service instance

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -80,13 +80,15 @@ public class DefaultServiceInstance implements ServiceInstance {
 	/**
 	 * Creates a URI from the given ServiceInstance's host:port.
 	 * @param instance the ServiceInstance.
-	 * @return URI of the form (secure)?https:http + "host:port" or "host" (port<=0).
+	 * @return URI of the form (secure)?https:http + "host:port". Scheme port default used if port not set.
 	 */
 	public static URI getUri(ServiceInstance instance) {
 		String scheme = (instance.isSecure()) ? "https" : "http";
-		String uri = (instance.getPort() > 0)
-			? String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort())
-			: String.format("%s://%s", scheme, instance.getHost());
+		int port = instance.getPort();
+		if (port <= 0) {
+		    port = (instance.isSecure()) ? 443 : 80;
+		}
+		String uri = String.format("%s://%s:%s", scheme, instance.getHost(), port);
 		return URI.create(uri);
 	}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -27,6 +27,7 @@ import java.util.Objects;
  * @author Spencer Gibb
  * @author Tim Ysewyn
  * @author Charu Covindane
+ * @author Neil Powell
  */
 public class DefaultServiceInstance implements ServiceInstance {
 
@@ -79,14 +80,13 @@ public class DefaultServiceInstance implements ServiceInstance {
 	/**
 	 * Creates a URI from the given ServiceInstance's host:port.
 	 * @param instance the ServiceInstance.
-	 * @return URI of the form (secure)?https:http + "host:port" or "host" if port not
-	 * valid (<=0).
+	 * @return URI of the form (secure)?https:http + "host:port" or "host" (port<=0).
 	 */
 	public static URI getUri(ServiceInstance instance) {
 		String scheme = (instance.isSecure()) ? "https" : "http";
 		String uri = (instance.getPort() > 0)
-				? String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort())
-				: String.format("%s://%s", scheme, instance.getHost());
+			? String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort())
+			: String.format("%s://%s", scheme, instance.getHost());
 		return URI.create(uri);
 	}
 
@@ -97,32 +97,32 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	@Override
 	public Map<String, String> getMetadata() {
-		return this.metadata;
+		return metadata;
 	}
 
 	@Override
 	public String getInstanceId() {
-		return this.instanceId;
+		return instanceId;
 	}
 
 	@Override
 	public String getServiceId() {
-		return this.serviceId;
+		return serviceId;
 	}
 
 	@Override
 	public String getHost() {
-		return this.host;
+		return host;
 	}
 
 	@Override
 	public int getPort() {
-		return this.port;
+		return port;
 	}
 
 	@Override
 	public boolean isSecure() {
-		return this.secure;
+		return secure;
 	}
 
 	public void setInstanceId(String instanceId) {
@@ -153,9 +153,8 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	@Override
 	public String toString() {
-		return "DefaultServiceInstance{" + "instanceId='" + this.instanceId + '\'' + ", serviceId='" + this.serviceId
-				+ '\'' + ", host='" + this.host + '\'' + ", port=" + this.port + ", secure=" + this.secure
-				+ ", metadata=" + this.metadata + '}';
+		return "DefaultServiceInstance{" + "instanceId='" + instanceId + '\'' + ", serviceId='" + serviceId + '\''
+				+ ", host='" + host + '\'' + ", port=" + port + ", secure=" + secure + ", metadata=" + metadata + '}';
 	}
 
 	@Override
@@ -167,14 +166,14 @@ public class DefaultServiceInstance implements ServiceInstance {
 			return false;
 		}
 		DefaultServiceInstance that = (DefaultServiceInstance) o;
-		return this.port == that.port && this.secure == that.secure && Objects.equals(this.instanceId, that.instanceId)
-				&& Objects.equals(this.serviceId, that.serviceId) && Objects.equals(this.host, that.host)
-				&& Objects.equals(this.metadata, that.metadata);
+		return port == that.port && secure == that.secure && Objects.equals(instanceId, that.instanceId)
+				&& Objects.equals(serviceId, that.serviceId) && Objects.equals(host, that.host)
+				&& Objects.equals(metadata, that.metadata);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.instanceId, this.serviceId, this.host, this.port, this.secure, this.metadata);
+		return Objects.hash(instanceId, serviceId, host, port, secure, metadata);
 	}
 
 }

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/DefaultServiceInstance.java
@@ -79,11 +79,14 @@ public class DefaultServiceInstance implements ServiceInstance {
 	/**
 	 * Creates a URI from the given ServiceInstance's host:port.
 	 * @param instance the ServiceInstance.
-	 * @return URI of the form (secure)?https:http + "host:port".
+	 * @return URI of the form (secure)?https:http + "host:port" or "host" if port not
+	 * valid (<=0).
 	 */
 	public static URI getUri(ServiceInstance instance) {
 		String scheme = (instance.isSecure()) ? "https" : "http";
-		String uri = String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort());
+		String uri = (instance.getPort() > 0)
+				? String.format("%s://%s:%s", scheme, instance.getHost(), instance.getPort())
+				: String.format("%s://%s", scheme, instance.getHost());
 		return URI.create(uri);
 	}
 
@@ -94,32 +97,32 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	@Override
 	public Map<String, String> getMetadata() {
-		return metadata;
+		return this.metadata;
 	}
 
 	@Override
 	public String getInstanceId() {
-		return instanceId;
+		return this.instanceId;
 	}
 
 	@Override
 	public String getServiceId() {
-		return serviceId;
+		return this.serviceId;
 	}
 
 	@Override
 	public String getHost() {
-		return host;
+		return this.host;
 	}
 
 	@Override
 	public int getPort() {
-		return port;
+		return this.port;
 	}
 
 	@Override
 	public boolean isSecure() {
-		return secure;
+		return this.secure;
 	}
 
 	public void setInstanceId(String instanceId) {
@@ -150,8 +153,9 @@ public class DefaultServiceInstance implements ServiceInstance {
 
 	@Override
 	public String toString() {
-		return "DefaultServiceInstance{" + "instanceId='" + instanceId + '\'' + ", serviceId='" + serviceId + '\''
-				+ ", host='" + host + '\'' + ", port=" + port + ", secure=" + secure + ", metadata=" + metadata + '}';
+		return "DefaultServiceInstance{" + "instanceId='" + this.instanceId + '\'' + ", serviceId='" + this.serviceId
+				+ '\'' + ", host='" + this.host + '\'' + ", port=" + this.port + ", secure=" + this.secure
+				+ ", metadata=" + this.metadata + '}';
 	}
 
 	@Override
@@ -163,14 +167,14 @@ public class DefaultServiceInstance implements ServiceInstance {
 			return false;
 		}
 		DefaultServiceInstance that = (DefaultServiceInstance) o;
-		return port == that.port && secure == that.secure && Objects.equals(instanceId, that.instanceId)
-				&& Objects.equals(serviceId, that.serviceId) && Objects.equals(host, that.host)
-				&& Objects.equals(metadata, that.metadata);
+		return this.port == that.port && this.secure == that.secure && Objects.equals(this.instanceId, that.instanceId)
+				&& Objects.equals(this.serviceId, that.serviceId) && Objects.equals(this.host, that.host)
+				&& Objects.equals(this.metadata, that.metadata);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(instanceId, serviceId, host, port, secure, metadata);
+		return Objects.hash(this.instanceId, this.serviceId, this.host, this.port, this.secure, this.metadata);
 	}
 
 }

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
@@ -46,7 +46,8 @@ public class SimpleDiscoveryClientTests {
 		Map<String, List<DefaultServiceInstance>> map = new HashMap<>();
 		DefaultServiceInstance service1Inst1 = new DefaultServiceInstance(null, null, "host1", 8080, false);
 		DefaultServiceInstance service1Inst2 = new DefaultServiceInstance(null, null, "host2", 0, true);
-		map.put("service1", Arrays.asList(service1Inst1, service1Inst2));
+		DefaultServiceInstance service1Inst3 = new DefaultServiceInstance(null, null, "host3", 0, false);
+		map.put("service1", Arrays.asList(service1Inst1, service1Inst2, service1Inst3));
 		simpleDiscoveryProperties.setInstances(map);
 		simpleDiscoveryProperties.init();
 		this.simpleDiscoveryClient = new SimpleDiscoveryClient(simpleDiscoveryProperties);
@@ -55,25 +56,27 @@ public class SimpleDiscoveryClientTests {
 	@Test
 	public void shouldBeAbleToRetrieveServiceDetailsByName() {
 		List<ServiceInstance> instances = this.simpleDiscoveryClient.getInstances("service1");
-		then(instances.size()).isEqualTo(2);
+		then(instances.size()).isEqualTo(3);
 		then(instances.get(0).getServiceId()).isEqualTo("service1");
 		then(instances.get(0).getHost()).isEqualTo("host1");
 		then(instances.get(0).getPort()).isEqualTo(8080);
 		then(instances.get(0).getUri()).isEqualTo(URI.create("http://host1:8080"));
 		then(instances.get(0).isSecure()).isEqualTo(false);
 		then(instances.get(0).getMetadata()).isNotNull();
-	}
 
-	@Test
-	public void shouldSupportUriWithoutPort() {
-		List<ServiceInstance> instances = this.simpleDiscoveryClient.getInstances("service1");
-		then(instances.size()).isEqualTo(2);
 		then(instances.get(1).getServiceId()).isEqualTo("service1");
 		then(instances.get(1).getHost()).isEqualTo("host2");
 		then(instances.get(1).getPort()).isEqualTo(0);
-		then(instances.get(1).getUri()).isEqualTo(URI.create("https://host2"));
+		then(instances.get(1).getUri()).isEqualTo(URI.create("https://host2:443"));
 		then(instances.get(1).isSecure()).isEqualTo(true);
 		then(instances.get(1).getMetadata()).isNotNull();
+		
+		then(instances.get(2).getServiceId()).isEqualTo("service1");
+		then(instances.get(2).getHost()).isEqualTo("host3");
+		then(instances.get(2).getPort()).isEqualTo(0);
+		then(instances.get(2).getUri()).isEqualTo(URI.create("http://host3:80"));
+		then(instances.get(2).isSecure()).isEqualTo(false);
+		then(instances.get(2).getMetadata()).isNotNull();
 	}
 
 }

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 
@@ -43,8 +42,10 @@ public class SimpleDiscoveryClientTests {
 		SimpleDiscoveryProperties simpleDiscoveryProperties = new SimpleDiscoveryProperties();
 
 		Map<String, List<DefaultServiceInstance>> map = new HashMap<>();
-		DefaultServiceInstance service1Inst1 = new DefaultServiceInstance(null, null, "host1", 8080, false);
-		DefaultServiceInstance service1Inst2 = new DefaultServiceInstance(null, null, "host2", 8443, true);
+		DefaultServiceInstance service1Inst1 = new DefaultServiceInstance(null, null,
+				"host1", 8080, false);
+		DefaultServiceInstance service1Inst2 = new DefaultServiceInstance(null, null,
+				"host2", 0, true);
 		map.put("service1", Arrays.asList(service1Inst1, service1Inst2));
 		simpleDiscoveryProperties.setInstances(map);
 		simpleDiscoveryProperties.init();
@@ -53,7 +54,8 @@ public class SimpleDiscoveryClientTests {
 
 	@Test
 	public void shouldBeAbleToRetrieveServiceDetailsByName() {
-		List<ServiceInstance> instances = this.simpleDiscoveryClient.getInstances("service1");
+		List<ServiceInstance> instances = this.simpleDiscoveryClient
+				.getInstances("service1");
 		then(instances.size()).isEqualTo(2);
 		then(instances.get(0).getServiceId()).isEqualTo("service1");
 		then(instances.get(0).getHost()).isEqualTo("host1");
@@ -61,6 +63,19 @@ public class SimpleDiscoveryClientTests {
 		then(instances.get(0).getUri()).isEqualTo(URI.create("http://host1:8080"));
 		then(instances.get(0).isSecure()).isEqualTo(false);
 		then(instances.get(0).getMetadata()).isNotNull();
+	}
+
+	@Test
+	public void shouldSupportUriWithoutPort() {
+		List<ServiceInstance> instances = this.simpleDiscoveryClient
+				.getInstances("service1");
+		then(instances.size()).isEqualTo(2);
+		then(instances.get(1).getServiceId()).isEqualTo("service1");
+		then(instances.get(1).getHost()).isEqualTo("host2");
+		then(instances.get(1).getPort()).isEqualTo(0);
+		then(instances.get(1).getUri()).isEqualTo(URI.create("https://host2"));
+		then(instances.get(1).isSecure()).isEqualTo(true);
+		then(instances.get(1).getMetadata()).isNotNull();
 	}
 
 }

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/simple/SimpleDiscoveryClientTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 
@@ -32,6 +33,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 /**
  * @author Biju Kunjummen
  * @author Charu Covindane
+ * @author Neil Powell
  */
 public class SimpleDiscoveryClientTests {
 
@@ -42,10 +44,8 @@ public class SimpleDiscoveryClientTests {
 		SimpleDiscoveryProperties simpleDiscoveryProperties = new SimpleDiscoveryProperties();
 
 		Map<String, List<DefaultServiceInstance>> map = new HashMap<>();
-		DefaultServiceInstance service1Inst1 = new DefaultServiceInstance(null, null,
-				"host1", 8080, false);
-		DefaultServiceInstance service1Inst2 = new DefaultServiceInstance(null, null,
-				"host2", 0, true);
+		DefaultServiceInstance service1Inst1 = new DefaultServiceInstance(null, null, "host1", 8080, false);
+		DefaultServiceInstance service1Inst2 = new DefaultServiceInstance(null, null, "host2", 0, true);
 		map.put("service1", Arrays.asList(service1Inst1, service1Inst2));
 		simpleDiscoveryProperties.setInstances(map);
 		simpleDiscoveryProperties.init();
@@ -54,8 +54,7 @@ public class SimpleDiscoveryClientTests {
 
 	@Test
 	public void shouldBeAbleToRetrieveServiceDetailsByName() {
-		List<ServiceInstance> instances = this.simpleDiscoveryClient
-				.getInstances("service1");
+		List<ServiceInstance> instances = this.simpleDiscoveryClient.getInstances("service1");
 		then(instances.size()).isEqualTo(2);
 		then(instances.get(0).getServiceId()).isEqualTo("service1");
 		then(instances.get(0).getHost()).isEqualTo("host1");
@@ -67,8 +66,7 @@ public class SimpleDiscoveryClientTests {
 
 	@Test
 	public void shouldSupportUriWithoutPort() {
-		List<ServiceInstance> instances = this.simpleDiscoveryClient
-				.getInstances("service1");
+		List<ServiceInstance> instances = this.simpleDiscoveryClient.getInstances("service1");
 		then(instances.size()).isEqualTo(2);
 		then(instances.get(1).getServiceId()).isEqualTo("service1");
 		then(instances.get(1).getHost()).isEqualTo("host2");


### PR DESCRIPTION
The current DefaultServiceInstance getUri() method does not support URIs without a port. This is problematic when using the Spring Cloud Loadbalancer for DNS subdomain-based targets. For example service instances in different K8 clusters/CF foundations. This pull request adds a simple condition for constructing the uri string based on the port being > 0.