### PR TITLE
Inject the class loader from the parent context into the child context

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/named/NamedContextFactory.java
@@ -47,6 +47,7 @@ import org.springframework.core.env.MapPropertySource;
  * @param <C> specification
  * @author Spencer Gibb
  * @author Dave Syer
+ * @author Tommy Karlsson
  */
 // TODO: add javadoc
 public abstract class NamedContextFactory<C extends NamedContextFactory.Specification>

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/named/NamedContextFactoryTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/named/NamedContextFactoryTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 /**
  * @author Spencer Gibb
+ * @author Tommy Karlsson
  */
 public class NamedContextFactoryTests {
 
@@ -105,8 +106,7 @@ public class NamedContextFactoryTests {
 	}
 
 	@Test
-	public void testBadThreadContextClassLoader() throws InterruptedException, ExecutionException, TimeoutException {
-
+	void testBadThreadContextClassLoader() throws InterruptedException, ExecutionException, TimeoutException {
 		AnnotationConfigApplicationContext parent = new AnnotationConfigApplicationContext();
 		parent.setClassLoader(ClassUtils.getDefaultClassLoader());
 		parent.register(BaseConfig.class);
@@ -128,7 +128,7 @@ public class NamedContextFactoryTests {
 	static class ThrowingClassLoader extends ClassLoader {
 
 		ThrowingClassLoader() {
-			super("Throwing classloader", null);
+			super(null);
 		}
 
 		@Override


### PR DESCRIPTION
`ConditionEvaluator` extracts the class loader from the bean factory at instantiation, and then uses said classloader to load classes when evaluating conditionals. Hence, we need to inject the parent class loader into a bean factory that we inject into the child context. This fix is an extension of the fix made in spring-cloud/spring-cloud-netflix#3101.

Fixes spring-cloud/spring-cloud-openfeign#475