### PR TITLE
fix bug of XForwardedHeadersTransformer ConditionalOnBean

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Olga Maciaszek-Sharma
  * @author Tim Ysewyn
  * @author BaoLin Zhu
+ * @author changjin wei(魏昌进)
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDiscoveryEnabled
@@ -97,7 +98,7 @@ public class LoadBalancerClientConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnBean({ XForwardedHeadersTransformer.class, LoadBalancerClientFactory.class })
+		@ConditionalOnBean(LoadBalancerClientFactory.class)
 		@ConditionalOnMissingBean
 		public XForwardedHeadersTransformer xForwarderHeadersTransformer(LoadBalancerClientFactory clientFactory) {
 			return new XForwardedHeadersTransformer(clientFactory);


### PR DESCRIPTION
Should use `@ConditionalOnBean(LoadBalancerClientFactory.class)` on `xForwarderHeadersTransformer` method, not `@ConditionalOnBean({ XForwardedHeadersTransformer.class, LoadBalancerClientFactory.class })`