### PR TITLE
Do not move position when there is only 1 instance

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
@@ -100,6 +100,12 @@ public class RoundRobinLoadBalancer implements ReactorServiceInstanceLoadBalance
 			return new EmptyResponse();
 		}
 
+		// Do not move position when there is only 1 instance, especially some suppliers
+		// have already filtered instances
+		if (instances.size() == 1) {
+			return new DefaultResponse(instances.get(0));
+		}
+
 		// Ignore the sign bit, this allows pos to loop sequentially from 0 to
 		// Integer.MAX_VALUE
 		int pos = this.position.incrementAndGet() & Integer.MAX_VALUE;

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -59,7 +59,7 @@ class RoundRobinLoadBalancerTests {
 		ServiceInstanceListSupplier supplier = mock(ServiceInstanceListSupplier.class);
 		when(supplier.get(any())).thenReturn(Flux.just(Collections.singletonList(new DefaultServiceInstance())));
 		RoundRobinLoadBalancer loadBalancer = new RoundRobinLoadBalancer(new SimpleObjectProvider<>(supplier),
-				"shouldStartFromZeroWhenPositiveOverflow", 0);
+				"shouldNotMovePositionIfOnlyOneInstance", 0);
 		loadBalancer.choose().block();
 		assertThat(loadBalancer.position).hasValue(0);
 		loadBalancer.choose().block();

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -60,8 +60,10 @@ class RoundRobinLoadBalancerTests {
 		when(supplier.get(any())).thenReturn(Flux.just(Collections.singletonList(new DefaultServiceInstance())));
 		RoundRobinLoadBalancer loadBalancer = new RoundRobinLoadBalancer(new SimpleObjectProvider<>(supplier),
 				"shouldNotMovePositionIfOnlyOneInstance", 0);
+
 		loadBalancer.choose().block();
 		assertThat(loadBalancer.position).hasValue(0);
+
 		loadBalancer.choose().block();
 		assertThat(loadBalancer.position).hasValue(0);
 	}

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.loadbalancer.support.SimpleObjectProvider;
 
@@ -50,6 +51,18 @@ class RoundRobinLoadBalancerTests {
 	@Test
 	void shouldOrderEnforcedWhenPositiveOverflow() {
 		assertOrderEnforced(MAX_VALUE);
+	}
+
+	@Test
+	void shouldNotMovePositionIfOnlyOneInstance() {
+		ServiceInstanceListSupplier supplier = mock(ServiceInstanceListSupplier.class);
+		when(supplier.get(any())).thenReturn(Flux.just(List.of(new DefaultServiceInstance())));
+		RoundRobinLoadBalancer loadBalancer = new RoundRobinLoadBalancer(new SimpleObjectProvider<>(supplier),
+				"shouldStartFromZeroWhenPositiveOverflow", 0);
+		loadBalancer.choose().block();
+		assertThat(loadBalancer.position).hasValue(0);
+		loadBalancer.choose().block();
+		assertThat(loadBalancer.position).hasValue(0);
 	}
 
 	@SuppressWarnings("all")

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.loadbalancer.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class RoundRobinLoadBalancerTests {
 	@Test
 	void shouldNotMovePositionIfOnlyOneInstance() {
 		ServiceInstanceListSupplier supplier = mock(ServiceInstanceListSupplier.class);
-		when(supplier.get(any())).thenReturn(Flux.just(List.of(new DefaultServiceInstance())));
+		when(supplier.get(any())).thenReturn(Flux.just(Collections.singletonList(new DefaultServiceInstance())));
 		RoundRobinLoadBalancer loadBalancer = new RoundRobinLoadBalancer(new SimpleObjectProvider<>(supplier),
 				"shouldStartFromZeroWhenPositiveOverflow", 0);
 		loadBalancer.choose().block();


### PR DESCRIPTION
Fixes [gh-1144](https://github.com/spring-cloud/spring-cloud-commons/issues/1144)
Do not move position when there is only 1 instance, especially some suppliers have already filtered instances.