### PR TITLE
throws an exception if the instance is null

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RetryLoadBalancerInterceptor.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RetryLoadBalancerInterceptor.java
@@ -133,6 +133,7 @@ public class RetryLoadBalancerInterceptor implements ClientHttpRequestIntercepto
 											new RetryableRequestContext(null, new RequestData(request), hint)),
 									lbResponse)));
 				}
+				throw new IllegalStateException("No instances available for " + serviceName);
 			}
 			LoadBalancerRequestAdapter<ClientHttpResponse, RetryableRequestContext> lbRequest = new LoadBalancerRequestAdapter<>(
 					requestFactory.createRequest(request, body, execution),


### PR DESCRIPTION
Fix the problem that the real exception cannot be thrown, the stacktrace is as follows, the exception should not be `NullPointerException`
````
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[na:1.8.0_312]
	at org.springframework.cloud.loadbalancer.stats.MicrometerStatsLoadBalancerLifecycle.onComplete(MicrometerStatsLoadBalancerLifecycle.java:94) ~[spring-cloud-loadbalancer-3.1.4.jar:3.1.4]
	at org.springframework.cloud.loadbalancer.blocking.client.BlockingLoadBalancerClient.lambda$execute$5(BlockingLoadBalancerClient.java:128) ~[spring-cloud-loadbalancer-3.1.4.jar:3.1.4]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[na:1.8.0_312]
	at org.springframework.cloud.loadbalancer.blocking.client.BlockingLoadBalancerClient.execute(BlockingLoadBalancerClient.java:128) ~[spring-cloud-loadbalancer-3.1.4.jar:3.1.4]
	at org.springframework.cloud.client.loadbalancer.RetryLoadBalancerInterceptor.lambda$intercept$2(RetryLoadBalancerInterceptor.java:142) ~[classes/:3.1.4]
	at org.springframework.retry.support.RetryTemplate.doExecute(RetryTemplate.java:329) ~[spring-retry-1.3.3.jar:na]
	at org.springframework.retry.support.RetryTemplate.execute(RetryTemplate.java:225) ~[spring-retry-1.3.3.jar:na]
	at org.springframework.cloud.client.loadbalancer.RetryLoadBalancerInterceptor.intercept(RetryLoadBalancerInterceptor.java:91) ~[classes/:3.1.4]
	at org.springframework.http.client.InterceptingClientHttpRequest$InterceptingRequestExecution.execute(InterceptingClientHttpRequest.java:93) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.http.client.InterceptingClientHttpRequest.executeInternal(InterceptingClientHttpRequest.java:77) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.http.client.AbstractBufferingClientHttpRequest.executeInternal(AbstractBufferingClientHttpRequest.java:48) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.http.client.AbstractClientHttpRequest.execute(AbstractClientHttpRequest.java:66) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:776) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:711) ~[spring-web-5.3.23.jar:5.3.23]
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:602) ~[spring-web-5.3.23.jar:5.3.23]
````

## reproduce it
1.add `spring-retry`
````xml
<dependency>
    <groupId>org.springframework.retry</groupId>
    <artifactId>spring-retry</artifactId>
</dependency>
````
2.set `spring.cloud.loadbalancer.stats.micrometer.enabled` true
3.send a request with no available instances 