### PR TITLE
Add flexibility to zone preference in load balancing

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/ServiceInstanceListSupplierBuilder.java
@@ -225,6 +225,21 @@ public final class ServiceInstanceListSupplierBuilder {
 	}
 
 	/**
+	 * Adds a {@link ZonePreferenceServiceInstanceListSupplier} to the
+	 * {@link ServiceInstanceListSupplier} hierarchy.
+	 * @param zoneName desired zone for zone preference
+	 * @return the {@link ServiceInstanceListSupplierBuilder} object
+	 */
+	public ServiceInstanceListSupplierBuilder withZonePreference(String zoneName) {
+		DelegateCreator creator = (context, delegate) -> {
+			LoadBalancerZoneConfig zoneConfig = new LoadBalancerZoneConfig(zoneName);
+			return new ZonePreferenceServiceInstanceListSupplier(delegate, zoneConfig);
+		};
+		this.creators.add(creator);
+		return this;
+	}
+
+	/**
 	 * Adds a {@link RequestBasedStickySessionServiceInstanceListSupplier} to the
 	 * {@link ServiceInstanceListSupplier} hierarchy.
 	 * @return the {@link ServiceInstanceListSupplierBuilder} object


### PR DESCRIPTION
Enables to easily create custom load balancer configurations with zone preference, but a different zone then the one defined by spring.cloud.loadbalancer.zone