### PR TITLE
Update the compatibility verification class name for Spring Boot 3

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/configuration/SpringBootVersionVerifier.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/configuration/SpringBootVersionVerifier.java
@@ -83,7 +83,7 @@ class SpringBootVersionVerifier implements CompatibilityVerifier {
 				try {
 					// since 3.0
 					Class.forName(
-							"org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener");
+							"org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer");
 					return true;
 
 				}


### PR DESCRIPTION
I found to use this class name [ValidationConfigurationCustomizer](https://github.com/spring-projects/spring-boot/blob/ad63cb8e620097e2ad5bccf3af67e76dc87c528f/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/ConditionEvaluationReportLoggingListener.java#L50) to verify the compatibility for Spring Boot 3,
https://github.com/spring-cloud/spring-cloud-commons/blob/f26c2b3e933572c659e2925aea815bdf77f3372b/spring-cloud-commons/src/main/java/org/springframework/cloud/configuration/SpringBootVersionVerifier.java#L86, but this class has already existed since Spring Boot 2.

I am going to replace it with a new class [ValidationConfigurationCustomizer ](https://github.com/spring-projects/spring-boot/blob/ed5fe2d26ec4abad88f49005b499602dae4daa17/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationConfigurationCustomizer.java#L28) which it's only available in Spring Boot 3.