### PR TITLE
Fix DelegatingServiceInstanceListSupplier must

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.loadbalancer.core;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.util.Assert;
 
 /**
@@ -26,9 +27,10 @@ import org.springframework.util.Assert;
  *
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author hjk181
  */
 public abstract class DelegatingServiceInstanceListSupplier
-		implements ServiceInstanceListSupplier, InitializingBean, DisposableBean {
+		implements ServiceInstanceListSupplier, SelectedInstanceCallback, InitializingBean, DisposableBean {
 
 	protected final ServiceInstanceListSupplier delegate;
 
@@ -44,6 +46,13 @@ public abstract class DelegatingServiceInstanceListSupplier
 	@Override
 	public String getServiceId() {
 		return this.delegate.getServiceId();
+	}
+
+	@Override
+	public void selectedServiceInstance(ServiceInstance serviceInstance) {
+		if (delegate instanceof SelectedInstanceCallback selectedInstanceCallbackDelegate) {
+			selectedInstanceCallbackDelegate.selectedServiceInstance(serviceInstance);
+		}
 	}
 
 	@Override

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/DelegatingServiceInstanceListSupplier.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
- * @author hjk181
+ * @author Jürgen Kreitler
  */
 public abstract class DelegatingServiceInstanceListSupplier
 		implements ServiceInstanceListSupplier, SelectedInstanceCallback, InitializingBean, DisposableBean {

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.client.ServiceInstance;
  * chosen instance if it's available.
  *
  * @author Olga Maciaszek-Sharma
+ * @author hjk181
  * @since 2.2.7
  */
 public class SameInstancePreferenceServiceInstanceListSupplier extends DelegatingServiceInstanceListSupplier
@@ -72,6 +73,7 @@ public class SameInstancePreferenceServiceInstanceListSupplier extends Delegatin
 
 	@Override
 	public void selectedServiceInstance(ServiceInstance serviceInstance) {
+		super.selectedServiceInstance(serviceInstance);
 		if (previouslyReturnedInstance == null || !previouslyReturnedInstance.equals(serviceInstance)) {
 			previouslyReturnedInstance = serviceInstance;
 		}

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplier.java
@@ -30,7 +30,7 @@ import org.springframework.cloud.client.ServiceInstance;
  * chosen instance if it's available.
  *
  * @author Olga Maciaszek-Sharma
- * @author hjk181
+ * @author Jürgen Kreitler
  * @since 2.2.7
  */
 public class SameInstancePreferenceServiceInstanceListSupplier extends DelegatingServiceInstanceListSupplier

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link RetryAwareServiceInstanceListSupplier}.
  *
  * @author Olga Maciaszek-Sharma
- * @author hjk181
+ * @author Jürgen Kreitler
  */
 class RetryAwareServiceInstanceListSupplierTests {
 

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RetryAwareServiceInstanceListSupplierTests.java
@@ -27,11 +27,16 @@ import org.springframework.cloud.client.loadbalancer.RetryableRequestContext;
 import org.springframework.cloud.loadbalancer.support.ServiceInstanceListSuppliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link RetryAwareServiceInstanceListSupplier}.
  *
  * @author Olga Maciaszek-Sharma
+ * @author hjk181
  */
 class RetryAwareServiceInstanceListSupplierTests {
 
@@ -78,4 +83,12 @@ class RetryAwareServiceInstanceListSupplierTests {
 		assertThat(returnedInstances).containsExactly(firstInstance);
 	}
 
+	@Test
+	void shouldCallSelectedServiceInstanceOnItsDelegate() {
+		ServiceInstance firstInstance = instance(serviceId, "1host", false);
+		TestSelectedServiceInstanceSupplier delegate = mock(TestSelectedServiceInstanceSupplier.class);
+		DelegatingServiceInstanceListSupplier supplier = new RetryAwareServiceInstanceListSupplier(delegate);
+		supplier.selectedServiceInstance(firstInstance);
+		verify(delegate, times(1)).selectedServiceInstance(any(ServiceInstance.class));
+	}
 }

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancerTests.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Zhuozhi JI
- * @author hjk181
+ * @author Jürgen Kreitler
  */
 class RoundRobinLoadBalancerTests {
 

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
  * Tests for {@link SameInstancePreferenceServiceInstanceListSupplier}.
  *
  * @author Olga Maciaszek-Sharma
- * @author hjk181
+ * @author Jürgen Kreitler
  */
 class SameInstancePreferenceServiceInstanceListSupplierTests {
 

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/SameInstancePreferenceServiceInstanceListSupplierTests.java
@@ -26,13 +26,17 @@ import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link SameInstancePreferenceServiceInstanceListSupplier}.
  *
  * @author Olga Maciaszek-Sharma
+ * @author hjk181
  */
 class SameInstancePreferenceServiceInstanceListSupplierTests {
 
@@ -76,6 +80,15 @@ class SameInstancePreferenceServiceInstanceListSupplierTests {
 		List<ServiceInstance> instances = supplier.get().blockFirst();
 
 		assertThat(instances).hasSize(2);
+	}
+
+	@Test
+	void shouldCallSelectedServiceInstanceOnItsDelegate() {
+		ServiceInstance firstInstance = serviceInstance("test-4");
+		TestSelectedServiceInstanceSupplier delegate = mock(TestSelectedServiceInstanceSupplier.class);
+		DelegatingServiceInstanceListSupplier supplier = new SameInstancePreferenceServiceInstanceListSupplier(delegate);
+		supplier.selectedServiceInstance(firstInstance);
+		verify(delegate, times(1)).selectedServiceInstance(any(ServiceInstance.class));
 	}
 
 	private DefaultServiceInstance serviceInstance(String instanceId) {

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.loadbalancer.core;
+
+/**
+ * Test supplier interface extending {@link ServiceInstanceListSupplier} and {@link SelectedInstanceCallback}.
+ * Useful if you need to verify certain behavior happened on a mock for example.
+ *
+ * @author hjk181
+ */
+public interface TestSelectedServiceInstanceSupplier extends ServiceInstanceListSupplier, SelectedInstanceCallback {
+}

--- a/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
+++ b/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/core/TestSelectedServiceInstanceSupplier.java
@@ -20,7 +20,7 @@ package org.springframework.cloud.loadbalancer.core;
  * Test supplier interface extending {@link ServiceInstanceListSupplier} and {@link SelectedInstanceCallback}.
  * Useful if you need to verify certain behavior happened on a mock for example.
  *
- * @author hjk181
+ * @author Jürgen Kreitler
  */
 public interface TestSelectedServiceInstanceSupplier extends ServiceInstanceListSupplier, SelectedInstanceCallback {
 }


### PR DESCRIPTION
respect `SelectedInstanceCallback` on its delegate. Motivation behind is that some load balancer implementations like the `RoundRobinLoadBalancer` to call `selectedServiceInstance` on the `ServiceInstanceListSupplier` after choosing the next instance. However, when a `ServiceInstanceListSupplier` in wrapped by the `DelegatingServiceInstanceListSupplier` this functionality breaks, as `DelegatingServiceInstanceListSupplier` is not implementing `SelectedInstanceCallback` and therefore does ignoring that its delegate might also do. This might break the functionality of the delegate. Fixes gh-1221.