### PR TITLE
commonsFeatures method name updated to springCloudCommonsFeatures. 

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/CommonsClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/CommonsClientAutoConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
  * @author Tim Ysewyn
+ * @author Omer Naci Soydemir
  */
 @Configuration(proxyBeanMethods = false)
 public class CommonsClientAutoConfiguration {
@@ -75,7 +76,7 @@ public class CommonsClientAutoConfiguration {
 		}
 
 		@Bean
-		public HasFeatures commonsFeatures() {
+		public HasFeatures springCloudCommonsFeatures() {
 			return HasFeatures.abstractFeatures(DiscoveryClient.class, LoadBalancerClient.class);
 		}
 


### PR DESCRIPTION
Fixes #1229 | @ryanjbaxter I have updated it as you suggested.  I also saw that bean was formed successfully with `CommonsClientAutoConfigurationTests` : 

> _org.springframework.beans.factory.support.DefaultListableBeanFactory -- Creating shared instance of singleton bean '**springCloudCommonsFeatures**'_