### PR TITLE
Default value of `spring.cloud.loadbalancer.retry.enabled` remains consistent

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * {@link ReactiveLoadBalancer} used under the hood.
  *
  * @author Olga Maciaszek-Sharma
+ * @author Freeman Lau
  * @since 2.2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -47,8 +48,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class ReactorLoadBalancerClientAutoConfiguration {
 
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "false",
-			matchIfMissing = true)
+	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "false")
 	@Bean
 	public ReactorLoadBalancerExchangeFilterFunction loadBalancerExchangeFilterFunction(
 			ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory,
@@ -58,7 +58,8 @@ public class ReactorLoadBalancerClientAutoConfiguration {
 	}
 
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true")
+	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
+			matchIfMissing = true)
 	@Bean
 	public RetryableLoadBalancerExchangeFilterFunction retryableLoadBalancerExchangeFilterFunction(
 			ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory,
@@ -69,7 +70,8 @@ public class ReactorLoadBalancerClientAutoConfiguration {
 	}
 
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true")
+	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
+			matchIfMissing = true)
 	@Bean
 	public LoadBalancerRetryPolicy.Factory loadBalancerRetryPolicy(
 			ReactiveLoadBalancer.Factory<ServiceInstance> loadBalancerFactory) {

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfigurationTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerClientAutoConfigurationTests.java
@@ -56,13 +56,13 @@ public class ReactorLoadBalancerClientAutoConfigurationTests {
 		WebClient.Builder webClientBuilder = webClientBuilders.values().iterator().next();
 		then(webClientBuilder).isNotNull();
 
-		assertLoadBalanced(webClientBuilder, ReactorLoadBalancerExchangeFilterFunction.class);
+		assertLoadBalanced(webClientBuilder, RetryableLoadBalancerExchangeFilterFunction.class);
 
 		final Map<String, OneWebClientBuilder.TestService> testServiceMap = context
 				.getBeansOfType(OneWebClientBuilder.TestService.class);
 		then(testServiceMap).isNotNull().hasSize(1);
 		OneWebClientBuilder.TestService testService = testServiceMap.values().stream().findFirst().get();
-		assertLoadBalanced(testService.webClient, ReactorLoadBalancerExchangeFilterFunction.class);
+		assertLoadBalanced(testService.webClient, RetryableLoadBalancerExchangeFilterFunction.class);
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class ReactorLoadBalancerClientAutoConfigurationTests {
 		TwoWebClientBuilders.Two two = context.getBean(TwoWebClientBuilders.Two.class);
 
 		then(two.loadBalanced).isNotNull();
-		assertLoadBalanced(two.loadBalanced, ReactorLoadBalancerExchangeFilterFunction.class);
+		assertLoadBalanced(two.loadBalanced, RetryableLoadBalancerExchangeFilterFunction.class);
 
 		then(two.nonLoadBalanced).isNotNull();
 		then(getFilters(two.nonLoadBalanced)).isNullOrEmpty();

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/loadbalancer/reactive/ReactorLoadBalancerExchangeFilterFunctionTests.java
@@ -68,7 +68,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 class ReactorLoadBalancerExchangeFilterFunctionTests {
 
 	@Autowired
-	private ReactorLoadBalancerExchangeFilterFunction loadBalancerFunction;
+	private RetryableLoadBalancerExchangeFilterFunction loadBalancerFunction;
 
 	@Autowired
 	private SimpleDiscoveryProperties properties;

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/annotation/LoadBalancerClientConfiguration.java
@@ -59,6 +59,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author BaoLin Zhu
  * @author changjin wei(魏昌进)
  * @author Zhuozhi Ji
+ * @author Freeman Lau
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDiscoveryEnabled
@@ -300,7 +301,8 @@ public class LoadBalancerClientConfiguration {
 			super(ConfigurationPhase.REGISTER_BEAN);
 		}
 
-		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true")
+		@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
+				matchIfMissing = true)
 		static class LoadBalancerRetryEnabled {
 
 		}


### PR DESCRIPTION
This PR addresses one issue: The default value for `spring.cloud.loadbalancer.retry.enabled` is true, but this has not been consistently applied in some code.