### PR TITLE
Resolve bean post processor warnings

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestTemplate;
@@ -49,6 +50,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Will Tran
  * @author Gang Li
  * @author Olga Maciaszek-Sharma
+ * @author Henning Pöttker
  */
 @AutoConfiguration
 @Conditional(BlockingRestClassesPresentCondition.class)
@@ -86,7 +88,7 @@ public class LoadBalancerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public DeferringLoadBalancerInterceptor deferringLoadBalancerInterceptor(
+		public static DeferringLoadBalancerInterceptor deferringLoadBalancerInterceptor(
 				ObjectProvider<BlockingLoadBalancerInterceptor> loadBalancerInterceptorObjectProvider) {
 			return new DeferringLoadBalancerInterceptor(loadBalancerInterceptorObjectProvider);
 		}
@@ -94,8 +96,8 @@ public class LoadBalancerAutoConfiguration {
 		@Bean
 		@ConditionalOnBean(DeferringLoadBalancerInterceptor.class)
 		@ConditionalOnMissingBean
-		LoadBalancerRestClientBuilderBeanPostProcessor lbRestClientPostProcessor(
-				DeferringLoadBalancerInterceptor loadBalancerInterceptor, ApplicationContext context) {
+		static LoadBalancerRestClientBuilderBeanPostProcessor lbRestClientPostProcessor(
+				@Lazy DeferringLoadBalancerInterceptor loadBalancerInterceptor, ApplicationContext context) {
 			return new LoadBalancerRestClientBuilderBeanPostProcessor(loadBalancerInterceptor, context);
 		}
 

--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerBeanPostProcessorAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/reactive/LoadBalancerBeanPostProcessorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -39,6 +40,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * beans.
  *
  * @author Olga Maciaszek-Sharma
+ * @author Henning Pöttker
  * @since 2.2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -47,8 +49,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class LoadBalancerBeanPostProcessorAutoConfiguration {
 
 	@Bean
-	public LoadBalancerWebClientBuilderBeanPostProcessor loadBalancerWebClientBuilderBeanPostProcessor(
-			DeferringLoadBalancerExchangeFilterFunction deferringExchangeFilterFunction, ApplicationContext context) {
+	public static LoadBalancerWebClientBuilderBeanPostProcessor loadBalancerWebClientBuilderBeanPostProcessor(
+			@Lazy DeferringLoadBalancerExchangeFilterFunction deferringExchangeFilterFunction, ApplicationContext context) {
 		return new LoadBalancerWebClientBuilderBeanPostProcessor(deferringExchangeFilterFunction, context);
 	}
 
@@ -58,7 +60,7 @@ public class LoadBalancerBeanPostProcessorAutoConfiguration {
 
 		@Bean
 		@Primary
-		DeferringLoadBalancerExchangeFilterFunction<LoadBalancedExchangeFilterFunction> reactorDeferringLoadBalancerExchangeFilterFunction(
+		static DeferringLoadBalancerExchangeFilterFunction<LoadBalancedExchangeFilterFunction> reactorDeferringLoadBalancerExchangeFilterFunction(
 				ObjectProvider<LoadBalancedExchangeFilterFunction> exchangeFilterFunctionProvider) {
 			return new DeferringLoadBalancerExchangeFilterFunction<>(exchangeFilterFunctionProvider);
 		}


### PR DESCRIPTION
### Introduction

The PR resolves the remaining warnings about beans not being eligible for getting processed by all `BeanPostProcessor`s. Similar warnings have been reported in #1315 and fixed in #1319.

The warnings do not indicate a severe issue. But they lead to confusion among users and bad getting started experiences. And as the size of the PR shows, the required change is rather small.

### Reproducing the issue

The effectiveness of the change can be seen in the following tests:

- `LoadBalancerRequestFactoryConfigurationTests`
- `ReactorLoadBalancerClientAutoConfigurationTests`

Without the change, the test `LoadBalancerRequestFactoryConfigurationTests` logs the following warnings:

```
Bean 'org.springframework.cloud.client.loadbalancer.LoadBalancerAutoConfiguration$DeferringLoadBalancerInterceptorConfig' of type [org.springframework.cloud.client.loadbalancer.LoadBalancerAutoConfiguration$DeferringLoadBalancerInterceptorConfig] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). The currently created BeanPostProcessor [lbRestClientPostProcessor] is declared through a non-static factory method on that class; consider declaring it as static instead.
Bean 'deferringLoadBalancerInterceptor' of type [org.springframework.cloud.client.loadbalancer.DeferringLoadBalancerInterceptor] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [lbRestClientPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies.
```

Without the change, the test `ReactorLoadBalancerClientAutoConfigurationTests` logs the following warnings:

```
Bean 'loadBalancerBeanPostProcessorAutoConfiguration' of type [org.springframework.cloud.client.loadbalancer.reactive.LoadBalancerBeanPostProcessorAutoConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). The currently created BeanPostProcessor [loadBalancerWebClientBuilderBeanPostProcessor] is declared through a non-static factory method on that class; consider declaring it as static instead.
Bean 'org.springframework.cloud.client.loadbalancer.reactive.LoadBalancerBeanPostProcessorAutoConfiguration$ReactorDeferringLoadBalancerFilterConfig' of type [org.springframework.cloud.client.loadbalancer.reactive.LoadBalancerBeanPostProcessorAutoConfiguration$ReactorDeferringLoadBalancerFilterConfig] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [loadBalancerWebClientBuilderBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies.
Bean 'reactorDeferringLoadBalancerExchangeFilterFunction' of type [org.springframework.cloud.client.loadbalancer.reactive.DeferringLoadBalancerExchangeFilterFunction] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [loadBalancerWebClientBuilderBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies.
```

With the change, no such warnings appear.

### How it works

The PR works by using two mechanisms:

- By declaring the bean factory methods as `static`, the respective configuration class no longer needs to be instantiated before the methods are invoked.
- The bean post processors do not work with the injected `DeferringLoadBalancerInterceptor` or `DeferringLoadBalancerExchangeFilterFunction` themselves but only pass on references to builders. Therefore their injection points can be declared to be lazy.