### PR TITLE
Optimize instance selection performance

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.function.SingletonSupplier;
  * A random-based implementation of {@link ReactorServiceInstanceLoadBalancer}.
  *
  * @author Olga Maciaszek-Sharma
+ * @author Nan Chiu
  * @since 2.2.7
  */
 public class RandomLoadBalancer implements ReactorServiceInstanceLoadBalancer {

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.client.loadbalancer.DefaultResponse;
 import org.springframework.cloud.client.loadbalancer.EmptyResponse;
 import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.Response;
+import org.springframework.util.function.SingletonSupplier;
 
 /**
  * A random-based implementation of {@link ReactorServiceInstanceLoadBalancer}.
@@ -42,7 +43,7 @@ public class RandomLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 
 	private final String serviceId;
 
-	private ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
+	private final SingletonSupplier<ServiceInstanceListSupplier> serviceInstanceListSingletonSupplier;
 
 	/**
 	 * @param serviceInstanceListSupplierProvider a provider of
@@ -52,14 +53,15 @@ public class RandomLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	public RandomLoadBalancer(ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider,
 			String serviceId) {
 		this.serviceId = serviceId;
-		this.serviceInstanceListSupplierProvider = serviceInstanceListSupplierProvider;
+		this.serviceInstanceListSingletonSupplier = SingletonSupplier.of(
+				() -> serviceInstanceListSupplierProvider.getIfAvailable(NoopServiceInstanceListSupplier::new)
+		);
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Mono<Response<ServiceInstance>> choose(Request request) {
-		ServiceInstanceListSupplier supplier = serviceInstanceListSupplierProvider
-				.getIfAvailable(NoopServiceInstanceListSupplier::new);
+		ServiceInstanceListSupplier supplier = serviceInstanceListSingletonSupplier.obtain();
 		return supplier.get(request).next()
 				.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
 	}

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
@@ -62,7 +62,8 @@ public class RandomLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	@Override
 	public Mono<Response<ServiceInstance>> choose(Request request) {
 		ServiceInstanceListSupplier supplier = serviceInstanceListSingletonSupplier.obtain();
-		return supplier.get(request).next()
+		return supplier.get(request)
+				.next()
 				.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
 	}
 

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RandomLoadBalancer.java
@@ -63,8 +63,8 @@ public class RandomLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 	public Mono<Response<ServiceInstance>> choose(Request request) {
 		ServiceInstanceListSupplier supplier = serviceInstanceListSingletonSupplier.obtain();
 		return supplier.get(request)
-				.next()
-				.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
+			.next()
+			.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
 	}
 
 	private Response<ServiceInstance> processInstanceResponse(ServiceInstanceListSupplier supplier,

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
@@ -81,7 +81,8 @@ public class RoundRobinLoadBalancer implements ReactorServiceInstanceLoadBalance
 	// src/main/java/netflix/ocelli/loadbalancer/RoundRobinLoadBalancer.java
 	public Mono<Response<ServiceInstance>> choose(Request request) {
 		ServiceInstanceListSupplier supplier = serviceInstanceListSingletonSupplier.obtain();
-		return supplier.get(request).next()
+		return supplier.get(request)
+				.next()
 				.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
 	}
 

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
@@ -82,8 +82,8 @@ public class RoundRobinLoadBalancer implements ReactorServiceInstanceLoadBalance
 	public Mono<Response<ServiceInstance>> choose(Request request) {
 		ServiceInstanceListSupplier supplier = serviceInstanceListSingletonSupplier.obtain();
 		return supplier.get(request)
-				.next()
-				.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
+			.next()
+			.map(serviceInstances -> processInstanceResponse(supplier, serviceInstances));
 	}
 
 	private Response<ServiceInstance> processInstanceResponse(ServiceInstanceListSupplier supplier,

--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/core/RoundRobinLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.util.function.SingletonSupplier;
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
  * @author Zhuozhi JI
+ * @author Nan Chiu
  */
 public class RoundRobinLoadBalancer implements ReactorServiceInstanceLoadBalancer {
 
@@ -47,7 +48,7 @@ public class RoundRobinLoadBalancer implements ReactorServiceInstanceLoadBalance
 
 	final String serviceId;
 
-	final SingletonSupplier<ServiceInstanceListSupplier> serviceInstanceListSingletonSupplier;
+	private final SingletonSupplier<ServiceInstanceListSupplier> serviceInstanceListSingletonSupplier;
 
 	/**
 	 * @param serviceInstanceListSupplierProvider a provider of


### PR DESCRIPTION
Each time instance selection is performed during a request, the `ObjectProvider#getIfAvailable` method is called, and its reflection implementation causes some CPU consumption.