### PR TITLE
Deprecate unused EnvironmentUtils

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/env/EnvironmentUtils.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/env/EnvironmentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.core.env.Environment;
 /**
  * @author Spencer Gibb
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public final class EnvironmentUtils {
 
 	private EnvironmentUtils() {


### PR DESCRIPTION
EnvironmentUtils is not used in all spring-cloud projects, see https://github.com/search?q=org%3Aspring-cloud%20getSubProperties&type=code