### PR TITLE
Support configuring bean names as well as bean types for extra-refreshable and never-refreshable

### DIFF
--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -76,8 +76,8 @@
 |spring.cloud.loadbalancer.zone |  | Spring Cloud LoadBalancer zone.
 |spring.cloud.refresh.additional-property-sources-to-retain |  | Additional property sources to retain during a refresh. Typically only system property sources are retained. This property allows property sources, such as property sources created by EnvironmentPostProcessors to be retained as well.
 |spring.cloud.refresh.enabled | `+++true+++` | Enables autoconfiguration for the refresh scope and associated features.
-|spring.cloud.refresh.extra-refreshable | `+++true+++` | Additional class names for beans to post process into refresh scope.
-|spring.cloud.refresh.never-refreshable | `+++true+++` | Comma separated list of class names for beans to never be refreshed or rebound.
+|spring.cloud.refresh.extra-refreshable | `+++true+++` | Additional bean names or class names for beans to post process into refresh scope.
+|spring.cloud.refresh.never-refreshable | `+++true+++` | Comma separated list of bean names or class names for beans to never be refreshed or rebound.
 |spring.cloud.refresh.on-restart.enabled | `+++true+++` | Enable refreshing context on start.
 |spring.cloud.service-registry.auto-registration.enabled | `+++true+++` | Whether service auto-registration is enabled. Defaults to true.
 |spring.cloud.service-registry.auto-registration.fail-fast | `+++false+++` | Whether startup fails if there is no AutoServiceRegistration. Defaults to false.

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/autoconfigure/RefreshAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Venil Noronha
  * @author Olga Maciaszek-Sharma
+ * @author Yanming Zhou
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RefreshScope.class)
@@ -208,6 +209,9 @@ public class RefreshAutoConfiguration {
 			if (REFRESH_SCOPE_NAME.equals(scope)) {
 				// Already refresh scoped
 				return false;
+			}
+			if (this.refreshables.contains(name)) {
+				return true;
 			}
 			String type = definition.getBeanClassName();
 			if (!StringUtils.hasText(type) && registry instanceof BeanFactory) {

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  * the <code>@ConfigurationProperties</code> bean.
  *
  * @author Dave Syer
+ * @author Yanming Zhou
  * @see RefreshScope for a deeper and optionally more focused refresh of bean components.
  *
  */
@@ -131,7 +132,7 @@ public class ConfigurationPropertiesRebinder
 				// TODO: determine a more general approach to fix this.
 				// see
 				// https://github.com/spring-cloud/spring-cloud-commons/issues/571
-				if (getNeverRefreshable().contains(bean.getClass().getName())) {
+				if (getNeverRefreshable().contains(bean.getClass().getName()) || getNeverRefreshable().contains(name)) {
 					return false; // ignore
 				}
 				appContext.getAutowireCapableBeanFactory().destroyBean(bean);

--- a/spring-cloud-context/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-context/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -39,13 +39,13 @@
 		{
 			"name": "spring.cloud.refresh.extra-refreshable",
 			"type": "java.util.Set<java.lang.String>",
-			"description": "Additional class names for beans to post process into refresh scope.",
+			"description": "Additional bean names or class names for beans to post process into refresh scope.",
 			"defaultValue": true
 		},
 		{
 			"name": "spring.cloud.refresh.never-refreshable",
 			"type": "java.lang.String",
-			"description": "Comma separated list of class names for beans to never be refreshed or rebound.",
+			"description": "Comma separated list of bean names or class names for beans to never be refreshed or rebound.",
 			"defaultValue": true
 		},
 		{


### PR DESCRIPTION
Thanks to https://github.com/spring-projects/spring-boot/issues/22403, applications could define a bean in addition to an auto-configured bean of the same type, then we should support configuring bean names for fine-grained control.