### PR TITLE
Revise usage of @EnableConfigurationProperties

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/UtilAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/util/UtilAutoConfiguration.java
@@ -29,13 +29,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.cloud.util.enabled", matchIfMissing = true)
 @AutoConfigureOrder(0)
-@EnableConfigurationProperties
+@EnableConfigurationProperties(InetUtilsProperties.class)
 public class UtilAutoConfiguration {
-
-	@Bean
-	public InetUtilsProperties inetUtilsProperties() {
-		return new InetUtilsProperties();
-	}
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/actuator/FeaturesEndpointTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/actuator/FeaturesEndpointTests.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -85,7 +84,6 @@ public class FeaturesEndpointTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@EnableConfigurationProperties
 	public static class Config {
 
 		@Autowired(required = false)

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/health/DiscoveryClientHealthIndicatorTests.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.contributor.CompositeHealthContributor;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthContributor;
@@ -80,7 +79,6 @@ public class DiscoveryClientHealthIndicatorTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@EnableConfigurationProperties
 	public static class Config {
 
 		@Bean

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/TestBootstrapConfiguration.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/TestBootstrapConfiguration.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -37,7 +36,6 @@ import static org.springframework.cloud.bootstrap.TestHigherPriorityBootstrapCon
  */
 @Order(0)
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties
 public class TestBootstrapConfiguration {
 
 	public static List<String> fooSightings = null;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/config/BootstrapConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/config/BootstrapConfigurationTests.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
@@ -758,7 +757,6 @@ public class BootstrapConfigurationTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@EnableConfigurationProperties
 	protected static class BareConfiguration {
 
 	}


### PR DESCRIPTION
1. use `@EnableConfigurationProperties` to register configuration properties beans if the bean name is not relevant.
2. remove `@EnableConfigurationProperties` without specified value if the `@Configuration` class doesn't contain any `@ConfigurationProperties` bean.