### PR TITLE
Manage the version of okhttp in commons

### DIFF
--- a/spring-cloud-commons-dependencies/pom.xml
+++ b/spring-cloud-commons-dependencies/pom.xml
@@ -15,6 +15,7 @@
 	<name>spring-cloud-commons-dependencies</name>
 	<description>Spring Cloud Commons Dependencies</description>
 	<properties>
+		<okhttp.version>4.12.0</okhttp.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -52,6 +53,20 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-test-support</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<!-- Spring Boot removed its dependency management of okhttp in Spring Boot 3.4.0 -->
+			<!-- This resulted in a different version fo okhttp in Spring Cloud 2024.0.0 -->
+			<!-- We will now manage the version in Spring Cloud Commons to maintain backward compatibility -->
+			<!-- This can be removed in the next major -->
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp</artifactId>
+				<version>${okhttp.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>logging-interceptor</artifactId>
+				<version>${okhttp.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-commons/pom.xml
+++ b/spring-cloud-commons/pom.xml
@@ -177,6 +177,16 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>logging-interceptor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
[Spring Boot 3.4.0 no longer manages the version of okhttp](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#okhttp-dependency-management-removed).  To maintain backward compatibility we should manage it here in Spring Cloud Commons