### PR TITLE
Fix incorrect usage of `@AutoConfiguration`

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/LoadBalancerAutoConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Gang Li
  * @author Olga Maciaszek-Sharma
  * @author Henning Pöttker
+ * @author Yanming Zhou
  */
 @AutoConfiguration
 @Conditional(BlockingRestClassesPresentCondition.class)
@@ -83,7 +84,7 @@ public class LoadBalancerAutoConfiguration {
 		return new LoadBalancerRequestFactory(loadBalancerClient, transformers);
 	}
 
-	@AutoConfiguration
+	@Configuration(proxyBeanMethods = false)
 	static class DeferringLoadBalancerInterceptorConfig {
 
 		@Bean
@@ -122,7 +123,7 @@ public class LoadBalancerAutoConfiguration {
 
 	}
 
-	@AutoConfiguration
+	@Configuration(proxyBeanMethods = false)
 	@Conditional(RetryMissingOrDisabledCondition.class)
 	static class LoadBalancerInterceptorConfig {
 
@@ -165,7 +166,7 @@ public class LoadBalancerAutoConfiguration {
 	/**
 	 * Auto configuration for retry mechanism.
 	 */
-	@AutoConfiguration
+	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(RetryTemplate.class)
 	public static class RetryAutoConfiguration {
 


### PR DESCRIPTION
>> Generally, auto-configuration classes are top-level classes