### PR TITLE
Verify RestartEndpoint is enabled without causing a restart

### DIFF
--- a/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
@@ -58,7 +58,6 @@ public class LifecycleMvcAutoConfigurationTests {
 	}
 
 	@Test
-	@Disabled("TODO: https://github.com/spring-cloud/spring-cloud-commons/issues/1362")
 	public void environmentWebEndpointExtensionEnabled() {
 		beanCreated("writableEnvironmentEndpointWebExtension", "management.endpoint.env.enabled=true",
 				"management.endpoint.env.post.enabled=true", "management.endpoints.web.exposure.include=env");
@@ -77,7 +76,7 @@ public class LifecycleMvcAutoConfigurationTests {
 
 	@Test
 	public void restartEndpointEnabled() {
-		beanCreatedAndEndpointEnabled("restartEndpoint", RestartEndpoint.class, RestartEndpoint::restart,
+		beanCreatedAndEndpointEnabled("restartEndpoint", RestartEndpoint.class, RestartEndpoint::getTimeout,
 				"management.endpoint.restart.enabled=true", "management.endpoints.web.exposure.include=restart");
 	}
 


### PR DESCRIPTION
If the purpose of the test is to verify the bean is created and the endpoint enabled I don't think we need to trigger a restart.

Fixes #1362