### PR TITLE
Avoid expensive de-duplication in BootstrapPropertySource#getPropertyNames.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/BootstrapPropertySource.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/config/BootstrapPropertySource.java
@@ -16,13 +16,8 @@
 
 package org.springframework.cloud.bootstrap.config;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.bootstrap.config.PropertySourceBootstrapConfiguration.BOOTSTRAP_PROPERTY_SOURCE_NAME;
 
@@ -30,6 +25,7 @@ import static org.springframework.cloud.bootstrap.config.PropertySourceBootstrap
  * Enumerable wrapper for a property source.
  *
  * @author Ryan Baxter
+ * @author Nan Chiu
  */
 public class BootstrapPropertySource<T> extends EnumerablePropertySource<T> {
 
@@ -47,9 +43,7 @@ public class BootstrapPropertySource<T> extends EnumerablePropertySource<T> {
 
 	@Override
 	public String[] getPropertyNames() {
-		Set<String> names = new LinkedHashSet<>(Arrays.asList(this.delegate.getPropertyNames()));
-
-		return StringUtils.toStringArray(names);
+		return this.delegate.getPropertyNames();
 	}
 
 	public PropertySource<T> getDelegate() {


### PR DESCRIPTION
I have several existing applications that are still using Bootstrap for configuration refresh (version 3.1.x). Recently, I noticed that when there is a large amount of configuration, triggering a refresh can cause a significant CPU spike. I observed the same behavior in the newer version (2025.1.0) as well. The main overhead seems to come from ConfigurationProperties binding.

In addition, the cost of BootstrapPropertySource.getPropertyNames() is also quite noticeable. Since BootstrapPropertySource is essentially an enumerable wrapper, it does not seem necessary to perform de-duplication in getPropertyNames(). Therefore, this PR proposes changing the implementation to directly return the delegate’s getPropertyNames() result, in order to reduce some of the overhead.

Here is the minimal reproducible project along with its corresponding flame graph.

[demo.zip(version 2025.1.0)](https://github.com/user-attachments/files/24591750/demo.zip)
ps: The refresh is triggered via the refresh endpoint.

[flamegraph.html](https://github.com/user-attachments/files/24591720/flamegraph.html)

<img width="1973" height="451" alt="image-20260113210832210" src="https://github.com/user-attachments/assets/59fd26a0-edc9-4710-8490-da66386e6904" />

