### PR TITLE
Fix decryption of indexed (list) properties.

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/AbstractEnvironmentDecrypt.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/AbstractEnvironmentDecrypt.java
@@ -16,20 +16,19 @@
 
 package org.springframework.cloud.bootstrap.encrypt;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 /**
@@ -66,75 +65,43 @@ public abstract class AbstractEnvironmentDecrypt {
 	}
 
 	protected Map<String, Object> decrypt(TextEncryptor encryptor, PropertySources propertySources) {
-		Map<String, Object> properties = merge(propertySources);
-		decrypt(encryptor, properties);
-		return properties;
-	}
+		Map<String, Object> decryptedProperties = new LinkedHashMap<>();
+		var visitor = new PropertyVisitor();
 
-	protected Map<String, Object> merge(PropertySources propertySources) {
-		Map<String, Object> properties = new LinkedHashMap<>();
-		List<PropertySource<?>> sources = new ArrayList<>();
-		for (PropertySource<?> source : propertySources) {
-			sources.add(0, source);
-		}
-		for (PropertySource<?> source : sources) {
-			merge(source, properties);
-		}
-		return properties;
-	}
-
-	protected void merge(PropertySource<?> source, Map<String, Object> properties) {
-		if (source instanceof CompositePropertySource) {
-
-			List<PropertySource<?>> sources = new ArrayList<>(((CompositePropertySource) source).getPropertySources());
-			Collections.reverse(sources);
-
-			for (PropertySource<?> nested : sources) {
-				merge(nested, properties);
-			}
-
-		}
-		else if (source instanceof EnumerablePropertySource<?> enumerable) {
-			Map<String, Object> otherCollectionProperties = new LinkedHashMap<>();
-			boolean sourceHasDecryptedCollection = false;
-
-			for (String key : enumerable.getPropertyNames()) {
-				Object property = source.getProperty(key);
-				if (property != null) {
-					String value = property.toString();
-					if (value.startsWith(ENCRYPTED_PROPERTY_PREFIX)) {
-						properties.put(key, value);
-						if (COLLECTION_PROPERTY.matcher(key).matches()) {
-							sourceHasDecryptedCollection = true;
-						}
+		for (PropertySource<?> propertySource : propertySources) {
+			if (propertySource instanceof EnumerablePropertySource<?> enumerable) {
+				for (String propertyName : enumerable.getPropertyNames()) {
+					if (visitor.isVisited(propertyName)) {
+						continue;
 					}
-					else if (COLLECTION_PROPERTY.matcher(key).matches()) {
-						// put non-encrypted properties so merging of index properties
-						// happens correctly
-						otherCollectionProperties.put(key, value);
+
+					var collectionMatcher = COLLECTION_PROPERTY.matcher(propertyName);
+					if (collectionMatcher.matches()) {
+						// It is an indexed property. All items should be checked.
+						var name = collectionMatcher.group(1);
+						if (name == null) {
+							name = "";
+						}
+						var indexed = getPropertyValues(enumerable, encryptor, name);
+						// Include only if contains decrypted values
+						if (indexed.containsDecrypted) {
+							decryptedProperties.putAll(indexed.values);
+						}
+						visitor.visited(indexed.values.keySet());
 					}
 					else {
-						// override previously encrypted with non-encrypted property
-						properties.remove(key);
+						var single = getPropertyValue(enumerable, encryptor, propertyName);
+						// Include only if decrypted
+						if (single.isDecrypted) {
+							decryptedProperties.put(propertyName, single.value);
+						}
+						visitor.visited(propertyName);
 					}
 				}
 			}
-			// copy all indexed properties even if not encrypted
-			if (sourceHasDecryptedCollection && !otherCollectionProperties.isEmpty()) {
-				properties.putAll(otherCollectionProperties);
-			}
-
 		}
-	}
 
-	protected void decrypt(TextEncryptor encryptor, Map<String, Object> properties) {
-		properties.replaceAll((key, value) -> {
-			String valueString = value.toString();
-			if (!valueString.startsWith(ENCRYPTED_PROPERTY_PREFIX)) {
-				return value;
-			}
-			return decrypt(encryptor, key, valueString);
-		});
+		return decryptedProperties;
 	}
 
 	protected String decrypt(TextEncryptor encryptor, String key, String original) {
@@ -159,6 +126,71 @@ public abstract class AbstractEnvironmentDecrypt {
 			}
 			return "";
 		}
+	}
+
+	private IndexedValue getPropertyValues(EnumerablePropertySource<?> source, TextEncryptor encryptor,
+			String matchingName) {
+		// Adding '[' to search for exact names (foo[0] vs fooBar[0]).
+		String prefix = matchingName + "[";
+
+		boolean containsDecrypted = false;
+		Map<String, Object> elements = new HashMap<>();
+		for (String name : source.getPropertyNames()) {
+			if (COLLECTION_PROPERTY.matcher(name).matches() && name.startsWith(prefix)) {
+				var value = getPropertyValue(source, encryptor, name);
+				elements.put(name, value.value);
+				if (value.isDecrypted) {
+					containsDecrypted = true;
+				}
+			}
+		}
+
+		return new IndexedValue(elements, containsDecrypted);
+	}
+
+	private SingleValue getPropertyValue(PropertySource<?> source, TextEncryptor encryptor, String name) {
+		var value = source.getProperty(name);
+		if (value != null) {
+			var valueString = value.toString();
+			if (valueString.startsWith(ENCRYPTED_PROPERTY_PREFIX)) {
+				return new SingleValue(this.decrypt(encryptor, name, valueString), true);
+			}
+		}
+		return new SingleValue(value, false);
+	}
+
+	private record SingleValue(Object value, boolean isDecrypted) {
+	}
+
+	private record IndexedValue(Map<String, Object> values, boolean containsDecrypted) {
+	}
+
+	private static final class PropertyVisitor {
+
+		/**
+		 * Using SystemEnvironmentPropertySource, instead of a simple Map, just to cover
+		 * relaxed-binding cases.
+		 * <p>
+		 * See {@link SystemEnvironmentPropertySource#containsProperty(String)} for more
+		 * details.
+		 */
+		private final SystemEnvironmentPropertySource propertySource = new SystemEnvironmentPropertySource("visitor",
+				new HashMap<>());
+
+		boolean isVisited(String name) {
+			return this.propertySource.containsProperty(name);
+		}
+
+		void visited(String name) {
+			propertySource.getSource().put(name, "");
+		}
+
+		void visited(Set<String> names) {
+			for (String name : names) {
+				propertySource.getSource().put(name, "");
+			}
+		}
+
 	}
 
 }

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/DecryptEnvironmentPostProcessor.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/DecryptEnvironmentPostProcessor.java
@@ -61,9 +61,7 @@ public class DecryptEnvironmentPostProcessor extends AbstractEnvironmentDecrypt
 
 		MutablePropertySources propertySources = environment.getPropertySources();
 
-		environment.getPropertySources().remove(DECRYPTED_PROPERTY_SOURCE_NAME);
-
-		Map<String, Object> map = TextEncryptorUtils.decrypt(this, environment, propertySources);
+		Map<String, Object> map = TextEncryptorUtils.decrypt(this, environment);
 		if (!map.isEmpty()) {
 			// We have some decrypted properties
 			propertySources.addFirst(new SystemEnvironmentPropertySource(DECRYPTED_PROPERTY_SOURCE_NAME, map));

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/TextEncryptorUtils.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/encrypt/TextEncryptorUtils.java
@@ -30,7 +30,6 @@ import org.springframework.cloud.util.PropertyUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.MutablePropertySources;
 import org.springframework.security.crypto.encrypt.KeyStoreKeyFactory;
 import org.springframework.security.crypto.encrypt.RsaSecretEncryptor;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
@@ -45,13 +44,12 @@ public abstract class TextEncryptorUtils {
 	 * Decrypt environment. See {@link DecryptEnvironmentPostProcessor}.
 	 * @param decryptor the {@link AbstractEnvironmentDecrypt}
 	 * @param environment the environment to get key properties from.
-	 * @param propertySources the property sources to decrypt.
 	 * @return the decrypted properties.
 	 */
-	static Map<String, Object> decrypt(AbstractEnvironmentDecrypt decryptor, ConfigurableEnvironment environment,
-			MutablePropertySources propertySources) {
+	static Map<String, Object> decrypt(AbstractEnvironmentDecrypt decryptor, ConfigurableEnvironment environment) {
 		TextEncryptor encryptor = getTextEncryptor(decryptor, environment);
-		return decryptor.decrypt(encryptor, propertySources);
+
+		return decryptor.decrypt(encryptor, environment.getPropertySources());
 	}
 
 	static TextEncryptor getTextEncryptor(AbstractEnvironmentDecrypt decryptor, ConfigurableEnvironment environment) {

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/AbstractEnvironmentDecryptTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/bootstrap/encrypt/AbstractEnvironmentDecryptTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.bootstrap.encrypt;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.springframework.cloud.bootstrap.encrypt.AbstractEnvironmentDecrypt.DECRYPTED_PROPERTY_SOURCE_NAME;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class AbstractEnvironmentDecryptTests {
+
+	private final AbstractEnvironmentDecrypt decryptor = new AbstractEnvironmentDecrypt() {
+	};
+
+	private ConfigurableEnvironment environment;
+
+	@BeforeEach
+	void setup() {
+		environment = new AnnotationConfigApplicationContext().getEnvironment();
+	}
+
+	@Test
+	void decryptCipherKey() {
+		environment.getPropertySources().addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar")));
+
+		decrypt();
+
+		then(environment.getProperty("foo")).isEqualTo("bar");
+	}
+
+	@Test
+	void decryptCipherKeyWithPriority() {
+		environment.getPropertySources().addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar")));
+		environment.getPropertySources().addFirst(new MapPropertySource("source-2", Map.of("foo", "{cipher}spam")));
+
+		decrypt();
+		then(environment.getProperty("foo")).isEqualTo("spam");
+	}
+
+	@Test
+	void relaxedBinding() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1",
+					Map.of("foo.text", "{cipher}foo1", "bar_text", "bar1", "baz[0].text", "baz1")));
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-2",
+					Map.of("FOO_TEXT", "{cipher}foo2", "BAR_TEXT", "{cipher}bar2", "BAZ[0].TEXT", "{cipher}baz2")));
+
+		decrypt();
+
+		then(environment.getProperty("foo.text")).isEqualTo("foo2");
+		then(environment.getProperty("bar-text")).isEqualTo("bar2");
+		then(environment.getProperty("baz[0].text")).isEqualTo("baz2");
+	}
+
+	@Test
+	void errorOnDecrypt(CapturedOutput output) {
+		environment.getPropertySources().addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar")));
+
+		assertThatThrownBy(() -> decrypt(Encryptors.text("deadbeef", "AFFE37")))
+			.isInstanceOf(IllegalStateException.class);
+
+		// Assert logs contain warning even when exception thrown
+		then(output.toString()).contains("Cannot decrypt: key=foo");
+	}
+
+	@Test
+	void errorOnDecryptWhenFailOnErrorIsOff(CapturedOutput output) {
+		environment.getPropertySources().addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar")));
+		decryptor.setFailOnError(false);
+
+		decrypt(Encryptors.text("deadbeef", "AFFE37"));
+
+		// Assert logs contain warning
+		then(output.toString()).contains("Cannot decrypt: key=foo");
+		// Empty is the safest fallback for undecryptable cipher
+		then(environment.getProperty("foo")).isEqualTo("");
+	}
+
+	@Test
+	void indexedPropertiesAreCopied() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1",
+					Map.of("yours[0].someValue", "yourFoo", "yours[1].someValue", "yourBar")));
+		// collection with some encrypted keys and some not encrypted
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-2",
+					Map.of("mine[0].someValue", "Foo", "mine[0].someKey", "{cipher}Foo0", "mine[1].someValue", "Bar",
+							"mine[1].someKey", "{cipher}Bar1", "nonindexed", "nonindexval")));
+
+		decrypt();
+
+		then(environment.getProperty("mine[0].someValue")).isEqualTo("Foo");
+		then(environment.getProperty("mine[0].someKey")).isEqualTo("Foo0");
+		then(environment.getProperty("mine[1].someValue")).isEqualTo("Bar");
+		then(environment.getProperty("mine[1].someKey")).isEqualTo("Bar1");
+
+		then(environment.getProperty("yours[0].someValue")).isEqualTo("yourFoo");
+		then(environment.getProperty("yours[1].someValue")).isEqualTo("yourBar");
+	}
+
+	@Test
+	void indexedPropertiesAreCopiedOnlyIfEncrypted() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1",
+					Map.of("a[0]", "a0", "a[1]", "{cipher}a1", "b[0]", "b0", "b[1]", "b1")));
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-2", Map.of("b[0]", "updated-b0", "b[1]", "updated-b1")));
+
+		decrypt();
+
+		then(environment.getProperty("a[0]")).isEqualTo("a0");
+		then(environment.getProperty("a[1]")).isEqualTo("a1");
+
+		then(environment.getProperty("b[0]")).isEqualTo("updated-b0");
+		then(environment.getProperty("b[1]")).isEqualTo("updated-b1");
+
+		var decryptedPropertySource = environment.getPropertySources().get("decrypted");
+		then(decryptedPropertySource).isNotNull();
+		var source = decryptedPropertySource.getSource();
+		then(source).isInstanceOf(Map.class);
+		then(((Map<?, ?>) source).size()).as("decrypted property source had wrong size").isEqualTo(2);
+	}
+
+	@Test
+	void decryptCompositePropertySource() {
+		var cps = new CompositePropertySource("composite-source");
+		cps.addPropertySource(new MapPropertySource("dev-profile", Map.of("key", "{cipher}value1")));
+		cps.addPropertySource(new MapPropertySource("default-profile", Map.of("key", "{cipher}value2")));
+		environment.getPropertySources().addFirst(cps);
+
+		decrypt();
+		then(environment.getProperty("key")).isEqualTo("value1");
+	}
+
+	@Test
+	void propertySourcesOrderedCorrectlyWithUnencryptedOverrides() {
+		environment.getPropertySources().addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar")));
+		environment.getPropertySources().addFirst(new MapPropertySource("source-2", Map.of("foo", "spam")));
+
+		decrypt();
+
+		then(environment.getProperty("foo")).isEqualTo("spam");
+	}
+
+	@Test
+	void decryptOnlyIfNotOverridden() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1", Map.of("foo", "{cipher}bar", "foo2", "{cipher}bar2")));
+		environment.getPropertySources().addFirst(new MapPropertySource("source-2", Map.of("foo", "spam")));
+
+		decrypt();
+
+		then(environment.getProperty("foo2")).isEqualTo("bar2");
+		then(environment.getProperty("foo")).isEqualTo("spam");
+	}
+
+	@Test
+	void indexedPropertiesAreHandledCorrectly() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1",
+					Map.of("list[0].plain", "good", "list[0].cipher", "{cipher}bad")));
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-2", Map.of("list[0].plain", "well", "list[0].cipher", "worse")));
+
+		decrypt();
+
+		then(environment.getProperty("list[0].plain")).isEqualTo("well");
+		then(environment.getProperty("list[0].cipher")).isEqualTo("worse");
+	}
+
+	@Test
+	void anonymousIndexedPropertiesAreHandledCorrectly() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1", Map.of("[0].plain", "good", "[0].cipher", "{cipher}bad")));
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-2",
+					Map.of("[0].plain", "well", "[0].cipher", "{cipher}worse", "another[1].text", "old")));
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-3", Map.of("another[1].text", "updated")));
+
+		decrypt();
+
+		then(environment.getProperty("[0].plain")).isEqualTo("well");
+		then(environment.getProperty("[0].cipher")).isEqualTo("worse");
+		then(environment.getProperty("another[1].text")).isEqualTo("updated");
+	}
+
+	@Test
+	void indexedPropertiesWithSimilarNamesAreHandledCorrectly() {
+		environment.getPropertySources()
+			.addFirst(new MapPropertySource("source-1",
+					Map.of("foo[0]", "plain", "foo[1]", "{cipher}cipher", "fooBar[0]", "old")));
+		environment.getPropertySources().addFirst(new MapPropertySource("source-2", Map.of("fooBar[0]", "updated")));
+
+		decrypt();
+
+		then(environment.getProperty("foo[0]")).isEqualTo("plain");
+		then(environment.getProperty("foo[1]")).isEqualTo("cipher");
+		then(environment.getProperty("fooBar[0]")).isEqualTo("updated");
+	}
+
+	private void decrypt() {
+		decrypt(Encryptors.noOpText());
+	}
+
+	private void decrypt(TextEncryptor encryptor) {
+		var decrypted = decryptor.decrypt(encryptor, environment.getPropertySources());
+		environment.getPropertySources()
+			.addFirst(new SystemEnvironmentPropertySource(DECRYPTED_PROPERTY_SOURCE_NAME, decrypted));
+	}
+
+}


### PR DESCRIPTION
This pull request fixes #1253.  

It also fixes the following cases:

- In current (before this fix) implementation, when there is a list (indexed) property with encrypted items in a property source, **All** lists are copied to the new decrypted property-source, not only the one that has encrypted items. 

For example, in the following case only `my-list` should be copied to the decrypted property source but current implementation copies `another-list` as well. 
```
  my-list:
    - foo: '{cipher}4ffef9'
    - foo: 'plain'
    - foo: 'another plain value'
 
  another-list:
    - bar: plain
    - bar: another plain   
```

- When searching for properties, during decryption, relaxed-binding should be considered. Otherwise It is not possible to override the value of `foo.text : '{cipher}4ffef9'` by  adding `FOO_TEXT : 'updated value'`  in another property source with higher priority. 