### PR TITLE
warn log only if cache feature is enabled

### DIFF
--- a/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/LoadBalancerCacheAutoConfiguration.java
+++ b/spring-cloud-loadbalancer/src/main/java/org/springframework/cloud/loadbalancer/config/LoadBalancerCacheAutoConfiguration.java
@@ -75,6 +75,7 @@ public class LoadBalancerCacheAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@Conditional(OnCaffeineCacheMissingCondition.class)
+	@ConditionalOnClass(ConcurrentMapWithTimedEviction.class)
 	protected static class LoadBalancerCacheManagerWarnConfiguration {
 
 		@Bean


### PR DESCRIPTION
two problems:
1. LoadBalancerCaffeineWarnLogger print warn log even if cache configuration is not configured, this makes developer confused
2. warn log shows that framework uses default cache, but default cache is enabled when evictor dependency is added, but by default this dependency is absent