### PR TITLE
Recreate proxied @ConfigurationProperties beans on rebind

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.aop.framework.Advised;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
@@ -125,18 +126,28 @@ public class ConfigurationPropertiesRebinder
 	private boolean rebind(String name, ApplicationContext appContext) {
 		try {
 			Object bean = appContext.getBean(name);
+			Object target = bean;
+			boolean proxied = false;
 			if (AopUtils.isAopProxy(bean)) {
-				bean = ProxyUtils.getTargetObject(bean);
+				target = ProxyUtils.getTargetObject(bean);
+				proxied = true;
 			}
-			if (bean != null) {
+			if (target != null) {
 				// TODO: determine a more general approach to fix this.
 				// see
 				// https://github.com/spring-cloud/spring-cloud-commons/issues/571
-				if (getNeverRefreshable().contains(bean.getClass().getName()) || getNeverRefreshable().contains(name)) {
+				if (getNeverRefreshable().contains(target.getClass().getName())
+						|| getNeverRefreshable().contains(name)) {
 					return false; // ignore
 				}
-				appContext.getAutowireCapableBeanFactory().destroyBean(bean);
-				appContext.getAutowireCapableBeanFactory().initializeBean(bean, name);
+				appContext.getAutowireCapableBeanFactory().destroyBean(target);
+				if (proxied && bean instanceof Advised advised) {
+					Object freshBean = appContext.getAutowireCapableBeanFactory().createBean(target.getClass());
+					advised.setTargetSource(new org.springframework.aop.target.SingletonTargetSource(freshBean));
+				}
+				else {
+					appContext.getAutowireCapableBeanFactory().initializeBean(target, name);
+				}
 				return true;
 			}
 		}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -140,12 +140,22 @@ public class ConfigurationPropertiesRebinder
 						|| getNeverRefreshable().contains(name)) {
 					return false; // ignore
 				}
-				appContext.getAutowireCapableBeanFactory().destroyBean(target);
 				if (proxied && bean instanceof Advised advised) {
 					Object freshBean = appContext.getAutowireCapableBeanFactory().createBean(target.getClass());
-					advised.setTargetSource(new org.springframework.aop.target.SingletonTargetSource(freshBean));
+					if (AopUtils.isAopProxy(freshBean)) {
+						freshBean = ProxyUtils.getTargetObject(freshBean);
+					}
+					try {
+						advised.setTargetSource(new org.springframework.aop.target.SingletonTargetSource(freshBean));
+					}
+					catch (Exception ex) {
+						appContext.getAutowireCapableBeanFactory().destroyBean(freshBean);
+						throw ex;
+					}
+					appContext.getAutowireCapableBeanFactory().destroyBean(target);
 				}
 				else {
+					appContext.getAutowireCapableBeanFactory().destroyBean(target);
 					appContext.getAutowireCapableBeanFactory().initializeBean(target, name);
 				}
 				return true;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderFieldInitializerIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderFieldInitializerIntegrationTests.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.properties;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.cloud.context.properties.ConfigurationPropertiesRebinderFieldInitializerIntegrationTests.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * Tests that field initializers in {@code @ConfigurationProperties} beans are restored
+ * when properties are removed and the bean is rebound via a proxy.
+ *
+ * @see <a href=
+ * "https://github.com/spring-cloud/spring-cloud-commons/issues/1616">gh-1616</a>
+ */
+@SpringBootTest(classes = TestConfiguration.class, properties = "my.name=overridden")
+public class ConfigurationPropertiesRebinderFieldInitializerIntegrationTests {
+
+	@Autowired
+	private TestProperties properties;
+
+	@Autowired
+	private ConfigurationPropertiesRebinder rebinder;
+
+	@Autowired
+	private ConfigurableEnvironment environment;
+
+	@Test
+	@DirtiesContext
+	public void fieldInitializerRestoredAfterPropertyRemoval() {
+		// Initially the property overrides the field initializer
+		then(this.properties.getName()).isEqualTo("overridden");
+		then(this.properties.getTimeout()).isEqualTo(30);
+
+		// Override timeout as well
+		TestPropertyValues.of("my.timeout=60").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getTimeout()).isEqualTo(60);
+
+		// Remove all property sources that contain our overrides
+		MutablePropertySources sources = this.environment.getPropertySources();
+		sources.forEach(ps -> {
+			if (ps.containsProperty("my.name") || ps.containsProperty("my.timeout")) {
+				sources.remove(ps.getName());
+			}
+		});
+
+		this.rebinder.rebind();
+
+		// Field initializers should be restored
+		then(this.properties.getName()).isEqualTo("default-name");
+		then(this.properties.getTimeout()).isEqualTo(30);
+	}
+
+	@Test
+	@DirtiesContext
+	public void rebindStillWorksWithNewValues() {
+		then(this.properties.getName()).isEqualTo("overridden");
+
+		TestPropertyValues.of("my.name=updated").applyTo(this.environment);
+		this.rebinder.rebind();
+
+		then(this.properties.getName()).isEqualTo("updated");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties
+	@Import({ TestInterceptor.class, RefreshConfiguration.RebinderConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class, AopAutoConfiguration.class })
+	protected static class TestConfiguration {
+
+		@Bean
+		protected TestProperties testProperties() {
+			return new TestProperties();
+		}
+
+	}
+
+	@Aspect
+	protected static class TestInterceptor {
+
+		@Before("execution(* *..TestProperties.*(..))")
+		public void before() {
+			// Triggers AOP proxy creation for TestProperties
+		}
+
+	}
+
+	// Hack out a protected inner class for testing
+	protected static class RefreshConfiguration extends RefreshAutoConfiguration {
+
+		@Configuration(proxyBeanMethods = false)
+		protected static class RebinderConfiguration extends ConfigurationPropertiesRebinderAutoConfiguration {
+
+			public RebinderConfiguration(ApplicationContext context) {
+				super(context);
+			}
+
+		}
+
+	}
+
+	@ConfigurationProperties("my")
+	protected static class TestProperties {
+
+		private String name = "default-name";
+
+		private int timeout = 30;
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getTimeout() {
+			return this.timeout;
+		}
+
+		public void setTimeout(int timeout) {
+			this.timeout = timeout;
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

When a `@ConfigurationProperties` bean is wrapped in an AOP proxy and properties are removed from the `Environment`, calling `rebind()` previously left field initializers unrestored (they became `null` / `0` / `false` instead of their declared default values).

This change modifies `ConfigurationPropertiesRebinder.rebind()` so that when the bean is an AOP proxy, a fresh instance is created via `createBean()` and the proxy's `TargetSource` is replaced, ensuring field initializers are properly restored.

Non-proxied beans continue to use the existing `destroyBean()` + `initializeBean()` behavior for backwards compatibility.

Fixes gh-1616

## Changes

- `ConfigurationPropertiesRebinder`: detect proxied beans and replace the proxy target with a freshly created instance
- Added `ConfigurationPropertiesRebinderFieldInitializerIntegrationTests` to verify field initializer restoration