### PR TITLE
Reset bean to defaults before rebinding values

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.context.properties;
 
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -147,11 +148,19 @@ public class ConfigurationPropertiesRebinder
 				}
 				if (AopUtils.isAopProxy(bean) && bean instanceof Advised advised) {
 					Object target = ProxyUtils.getTargetObject(bean);
-					Object freshBean = appContext.getAutowireCapableBeanFactory().createBean(targetClass);
-					Object freshTarget = AopUtils.isAopProxy(freshBean) ? ProxyUtils.getTargetObject(freshBean)
-							: freshBean;
-					advised.setTargetSource(new SingletonTargetSource(freshTarget));
-					appContext.getAutowireCapableBeanFactory().destroyBean(target);
+					if (target != bean && !targetClass.isInterface()
+							&& !Modifier.isAbstract(targetClass.getModifiers())) {
+						Object freshBean = appContext.getAutowireCapableBeanFactory().createBean(targetClass);
+						Object freshTarget = AopUtils.isAopProxy(freshBean) ? ProxyUtils.getTargetObject(freshBean)
+								: freshBean;
+						advised.setTargetSource(new SingletonTargetSource(freshTarget));
+						appContext.getAutowireCapableBeanFactory().destroyBean(target);
+					}
+					else {
+						appContext.getAutowireCapableBeanFactory().destroyBean(target);
+						resetBeanToDefaults(target);
+						appContext.getAutowireCapableBeanFactory().initializeBean(target, name);
+					}
 				}
 				else {
 					appContext.getAutowireCapableBeanFactory().destroyBean(bean);

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -145,12 +145,13 @@ public class ConfigurationPropertiesRebinder
 				if (getNeverRefreshable().contains(targetClass.getName()) || getNeverRefreshable().contains(name)) {
 					return false; // ignore
 				}
-				if (AopUtils.isAopProxy(bean)) {
+				if (AopUtils.isAopProxy(bean) && bean instanceof Advised advised) {
 					Object target = ProxyUtils.getTargetObject(bean);
+					Object freshBean = appContext.getAutowireCapableBeanFactory().createBean(targetClass);
+					Object freshTarget = AopUtils.isAopProxy(freshBean) ? ProxyUtils.getTargetObject(freshBean)
+							: freshBean;
+					advised.setTargetSource(new SingletonTargetSource(freshTarget));
 					appContext.getAutowireCapableBeanFactory().destroyBean(target);
-					Object freshTarget = BeanUtils.instantiateClass(targetClass);
-					appContext.getAutowireCapableBeanFactory().initializeBean(freshTarget, name);
-					((Advised) bean).setTargetSource(new SingletonTargetSource(freshTarget));
 				}
 				else {
 					appContext.getAutowireCapableBeanFactory().destroyBean(bean);

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -203,19 +203,23 @@ public class ConfigurationPropertiesRebinder
 					Object defaultValue = defaultsWrapper.getPropertyValue(propertyName);
 					target.setPropertyValue(propertyName, defaultValue);
 				}
-				else if (target.isReadableProperty(propertyName)) {
+				else if (target.isReadableProperty(propertyName) && defaultsWrapper.isReadableProperty(propertyName)) {
 					Object value = target.getPropertyValue(propertyName);
-					if (value instanceof Collection<?> collection) {
+					Object defaultValue = defaultsWrapper.getPropertyValue(propertyName);
+					if (value instanceof Collection collection) {
 						collection.clear();
-					}
-					else if (value instanceof Map<?, ?> map) {
-						map.clear();
-					}
-					else if (value != null && defaultsWrapper.isReadableProperty(propertyName)) {
-						Object defaultValue = defaultsWrapper.getPropertyValue(propertyName);
-						if (defaultValue != null && !BeanUtils.isSimpleValueType(value.getClass())) {
-							resetProperties(value, defaultValue);
+						if (defaultValue instanceof Collection defaultCollection) {
+							collection.addAll(defaultCollection);
 						}
+					}
+					else if (value instanceof Map map) {
+						map.clear();
+						if (defaultValue instanceof Map defaultMap) {
+							map.putAll(defaultMap);
+						}
+					}
+					else if (value != null && defaultValue != null && !BeanUtils.isSimpleValueType(value.getClass())) {
+						resetProperties(value, defaultValue);
 					}
 				}
 			}

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -23,8 +23,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.aop.framework.Advised;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.aop.target.SingletonTargetSource;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
@@ -60,6 +65,8 @@ import org.springframework.util.StringUtils;
 @ManagedResource
 public class ConfigurationPropertiesRebinder
 		implements ApplicationContextAware, ApplicationListener<EnvironmentChangeEvent> {
+
+	private static final Log logger = LogFactory.getLog(ConfigurationPropertiesRebinder.class);
 
 	private ConfigurationPropertiesBeans beans;
 
@@ -130,19 +137,26 @@ public class ConfigurationPropertiesRebinder
 	private boolean rebind(String name, ApplicationContext appContext) {
 		try {
 			Object bean = appContext.getBean(name);
-			if (AopUtils.isAopProxy(bean)) {
-				bean = ProxyUtils.getTargetObject(bean);
-			}
 			if (bean != null) {
+				Class<?> targetClass = AopUtils.getTargetClass(bean);
 				// TODO: determine a more general approach to fix this.
 				// see
 				// https://github.com/spring-cloud/spring-cloud-commons/issues/571
-				if (getNeverRefreshable().contains(bean.getClass().getName()) || getNeverRefreshable().contains(name)) {
+				if (getNeverRefreshable().contains(targetClass.getName()) || getNeverRefreshable().contains(name)) {
 					return false; // ignore
 				}
-				appContext.getAutowireCapableBeanFactory().destroyBean(bean);
-				resetBeanToDefaults(bean);
-				appContext.getAutowireCapableBeanFactory().initializeBean(bean, name);
+				if (AopUtils.isAopProxy(bean)) {
+					Object target = ProxyUtils.getTargetObject(bean);
+					appContext.getAutowireCapableBeanFactory().destroyBean(target);
+					Object freshTarget = BeanUtils.instantiateClass(targetClass);
+					appContext.getAutowireCapableBeanFactory().initializeBean(freshTarget, name);
+					((Advised) bean).setTargetSource(new SingletonTargetSource(freshTarget));
+				}
+				else {
+					appContext.getAutowireCapableBeanFactory().destroyBean(bean);
+					resetBeanToDefaults(bean);
+					appContext.getAutowireCapableBeanFactory().initializeBean(bean, name);
+				}
 				return true;
 			}
 		}
@@ -162,15 +176,24 @@ public class ConfigurationPropertiesRebinder
 	 * not retain stale values after rebinding.
 	 */
 	private void resetBeanToDefaults(Object bean) {
+		Class<?> targetClass = AopUtils.getTargetClass(bean);
+		Object freshInstance;
 		try {
-			Object freshInstance = BeanUtils.instantiateClass(bean.getClass());
-			BeanWrapper target = new BeanWrapperImpl(bean);
-			BeanWrapper defaults = new BeanWrapperImpl(freshInstance);
-			for (PropertyDescriptor pd : target.getPropertyDescriptors()) {
-				String propertyName = pd.getName();
-				if ("class".equals(propertyName)) {
-					continue;
-				}
+			freshInstance = BeanUtils.instantiateClass(targetClass);
+		}
+		catch (Exception ex) {
+			logger.warn("Cannot create default instance of " + targetClass.getName()
+					+ " for reset; skipping property reset", ex);
+			return;
+		}
+		BeanWrapper target = new BeanWrapperImpl(bean);
+		BeanWrapper defaults = new BeanWrapperImpl(freshInstance);
+		for (PropertyDescriptor pd : target.getPropertyDescriptors()) {
+			String propertyName = pd.getName();
+			if ("class".equals(propertyName)) {
+				continue;
+			}
+			try {
 				if (target.isWritableProperty(propertyName) && defaults.isReadableProperty(propertyName)) {
 					Object defaultValue = defaults.getPropertyValue(propertyName);
 					target.setPropertyValue(propertyName, defaultValue);
@@ -185,10 +208,11 @@ public class ConfigurationPropertiesRebinder
 					}
 				}
 			}
-		}
-		catch (Exception ex) {
-			// If we cannot create a default instance (e.g. no default constructor),
-			// skip the reset and rely on the existing rebind behavior.
+			catch (Exception ex) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Failed to reset property '" + propertyName + "' on " + targetClass.getName(), ex);
+				}
+			}
 		}
 	}
 

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.context.properties;
 
+import java.beans.PropertyDescriptor;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +25,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -136,6 +141,7 @@ public class ConfigurationPropertiesRebinder
 					return false; // ignore
 				}
 				appContext.getAutowireCapableBeanFactory().destroyBean(bean);
+				resetBeanToDefaults(bean);
 				appContext.getAutowireCapableBeanFactory().initializeBean(bean, name);
 				return true;
 			}
@@ -149,6 +155,41 @@ public class ConfigurationPropertiesRebinder
 			throw new IllegalStateException("Cannot rebind to " + name, e);
 		}
 		return false;
+	}
+
+	/**
+	 * Reset bean properties to their class-level defaults so that removed properties do
+	 * not retain stale values after rebinding.
+	 */
+	private void resetBeanToDefaults(Object bean) {
+		try {
+			Object freshInstance = BeanUtils.instantiateClass(bean.getClass());
+			BeanWrapper target = new BeanWrapperImpl(bean);
+			BeanWrapper defaults = new BeanWrapperImpl(freshInstance);
+			for (PropertyDescriptor pd : target.getPropertyDescriptors()) {
+				String propertyName = pd.getName();
+				if ("class".equals(propertyName)) {
+					continue;
+				}
+				if (target.isWritableProperty(propertyName) && defaults.isReadableProperty(propertyName)) {
+					Object defaultValue = defaults.getPropertyValue(propertyName);
+					target.setPropertyValue(propertyName, defaultValue);
+				}
+				else if (target.isReadableProperty(propertyName)) {
+					Object value = target.getPropertyValue(propertyName);
+					if (value instanceof Collection<?> collection) {
+						collection.clear();
+					}
+					else if (value instanceof Map<?, ?> map) {
+						map.clear();
+					}
+				}
+			}
+		}
+		catch (Exception ex) {
+			// If we cannot create a default instance (e.g. no default constructor),
+			// skip the reset and rely on the existing rebind behavior.
+		}
 	}
 
 	@ManagedAttribute

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -187,16 +187,20 @@ public class ConfigurationPropertiesRebinder
 					+ " for reset; skipping property reset", ex);
 			return;
 		}
+		resetProperties(bean, freshInstance);
+	}
+
+	private void resetProperties(Object bean, Object defaults) {
 		BeanWrapper target = new BeanWrapperImpl(bean);
-		BeanWrapper defaults = new BeanWrapperImpl(freshInstance);
+		BeanWrapper defaultsWrapper = new BeanWrapperImpl(defaults);
 		for (PropertyDescriptor pd : target.getPropertyDescriptors()) {
 			String propertyName = pd.getName();
 			if ("class".equals(propertyName)) {
 				continue;
 			}
 			try {
-				if (target.isWritableProperty(propertyName) && defaults.isReadableProperty(propertyName)) {
-					Object defaultValue = defaults.getPropertyValue(propertyName);
+				if (target.isWritableProperty(propertyName) && defaultsWrapper.isReadableProperty(propertyName)) {
+					Object defaultValue = defaultsWrapper.getPropertyValue(propertyName);
 					target.setPropertyValue(propertyName, defaultValue);
 				}
 				else if (target.isReadableProperty(propertyName)) {
@@ -207,11 +211,18 @@ public class ConfigurationPropertiesRebinder
 					else if (value instanceof Map<?, ?> map) {
 						map.clear();
 					}
+					else if (value != null && defaultsWrapper.isReadableProperty(propertyName)) {
+						Object defaultValue = defaultsWrapper.getPropertyValue(propertyName);
+						if (defaultValue != null && !BeanUtils.isSimpleValueType(value.getClass())) {
+							resetProperties(value, defaultValue);
+						}
+					}
 				}
 			}
 			catch (Exception ex) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("Failed to reset property '" + propertyName + "' on " + targetClass.getName(), ex);
+					logger.debug("Failed to reset property '" + propertyName + "' on "
+							+ AopUtils.getTargetClass(bean).getName(), ex);
 				}
 			}
 		}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.context.properties;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -105,6 +108,38 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 	@Test
 	@DirtiesContext
+	public void testCollectionWithDefaultsRestoredOnRemoval() {
+		then(this.properties.getTags()).containsExactly("alpha", "beta");
+		// Override the collection
+		TestPropertyValues.of("test.tags[0]=custom").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getTags()).containsExactly("custom");
+		// Remove the property
+		Map<String, Object> map = findTestProperties();
+		map.remove("test.tags[0]");
+		this.rebinder.rebind();
+		// Should revert to field initializer defaults
+		then(this.properties.getTags()).containsExactly("alpha", "beta");
+	}
+
+	@Test
+	@DirtiesContext
+	public void testMapWithDefaultsRestoredOnRemoval() {
+		then(this.properties.getDefaults()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+		// Override the map
+		TestPropertyValues.of("test.defaults.key1=custom").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getDefaults()).containsEntry("key1", "custom");
+		// Remove the property
+		Map<String, Object> map = findTestProperties();
+		map.remove("test.defaults.key1");
+		this.rebinder.rebind();
+		// Should revert to field initializer defaults
+		then(this.properties.getDefaults()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+	}
+
+	@Test
+	@DirtiesContext
 	public void testNestedPropertyWithoutSetterRestoredOnRemoval() {
 		then(this.properties.getNested().getHost()).isEqualTo("default-host");
 		// Set a nested value
@@ -165,6 +200,10 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 		private String name = "default-name";
 
+		private final List<String> tags = new ArrayList<>(List.of("alpha", "beta"));
+
+		private final Map<String, String> defaults = new LinkedHashMap<>(Map.of("key1", "value1", "key2", "value2"));
+
 		private final NestedProperties nested = new NestedProperties();
 
 		public String getMessage() {
@@ -189,6 +228,14 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+
+		public List<String> getTags() {
+			return this.tags;
+		}
+
+		public Map<String, String> getDefaults() {
+			return this.defaults;
 		}
 
 		public NestedProperties getNested() {

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
@@ -16,12 +16,10 @@
 
 package org.springframework.cloud.context.properties;
 
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
-import org.springframework.cloud.context.properties.ConfigurationPropertiesRebinderListIntegrationTests.TestConfiguration;
+import org.springframework.cloud.context.properties.ConfigurationPropertiesRebinderClearIntegrationTests.TestConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,8 +39,8 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@SpringBootTest(classes = TestConfiguration.class, properties = "messages=one,two")
-public class ConfigurationPropertiesRebinderListIntegrationTests {
+@SpringBootTest(classes = TestConfiguration.class, properties = { "test.message=Hello", "test.count=5" })
+public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 	@Autowired
 	private TestProperties properties;
@@ -55,22 +53,54 @@ public class ConfigurationPropertiesRebinderListIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void testAppendProperties() {
-		then(this.properties.getMessages()).containsOnly("one", "two");
-		TestPropertyValues.of("messages[0]:foo").applyTo(this.environment);
+	public void testPropertyClearedToNull() {
+		then(this.properties.getMessage()).isEqualTo("Hello");
+		// Remove the property from the environment
+		Map<String, Object> map = findTestProperties();
+		map.remove("test.message");
+		// Rebind
 		this.rebinder.rebind();
-		then(this.properties.getMessages()).containsOnly("foo");
+		// The property should be cleared to its default (null)
+		then(this.properties.getMessage()).isNull();
 	}
 
 	@Test
 	@DirtiesContext
-	public void testReplaceProperties() {
-		then(this.properties.getMessages()).containsOnly("one", "two");
+	public void testPrimitivePropertyClearedToDefault() {
+		then(this.properties.getCount()).isEqualTo(5);
+		// Remove the property from the environment
 		Map<String, Object> map = findTestProperties();
-		map.clear();
-		TestPropertyValues.of("messages[0]:foo").applyTo(this.environment);
+		map.remove("test.count");
+		// Rebind
 		this.rebinder.rebind();
-		then(this.properties.getMessages()).containsOnly("foo");
+		// The primitive property should be cleared to its class-level default (0)
+		then(this.properties.getCount()).isEqualTo(0);
+	}
+
+	@Test
+	@DirtiesContext
+	public void testPropertyWithFieldDefaultRestoredOnRemoval() {
+		then(this.properties.getName()).isEqualTo("default-name");
+		// Set a value
+		TestPropertyValues.of("test.name=custom").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getName()).isEqualTo("custom");
+		// Remove the property
+		Map<String, Object> map = findTestProperties();
+		map.remove("test.name");
+		this.rebinder.rebind();
+		// Should revert to field initializer default
+		then(this.properties.getName()).isEqualTo("default-name");
+	}
+
+	@Test
+	@DirtiesContext
+	public void testPropertyChangedToNewValue() {
+		then(this.properties.getMessage()).isEqualTo("Hello");
+		// Change the property
+		TestPropertyValues.of("test.message=World").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getMessage()).isEqualTo("World");
 	}
 
 	private Map<String, Object> findTestProperties() {
@@ -84,24 +114,13 @@ public class ConfigurationPropertiesRebinderListIntegrationTests {
 		throw new IllegalStateException("Could not find test property source");
 	}
 
-	@Test
-	@DirtiesContext
-	public void testReplacePropertiesWithCommaSeparated() {
-		then(this.properties.getMessages()).containsOnly("one", "two");
-		Map<String, Object> map = findTestProperties();
-		map.clear();
-		TestPropertyValues.of("messages:foo").applyTo(this.environment);
-		this.rebinder.rebind();
-		then(this.properties.getMessages()).containsOnly("foo");
-	}
-
 	@Configuration(proxyBeanMethods = false)
 	@EnableConfigurationProperties
 	@Import({ RefreshConfiguration.RebinderConfiguration.class, PropertyPlaceholderAutoConfiguration.class })
 	protected static class TestConfiguration {
 
 		@Bean
-		protected TestProperties localTestProperties() {
+		protected TestProperties testProperties() {
 			return new TestProperties();
 		}
 
@@ -121,28 +140,37 @@ public class ConfigurationPropertiesRebinderListIntegrationTests {
 
 	}
 
-	@ConfigurationProperties
-	protected static class TestProperties implements InitializingBean {
+	@ConfigurationProperties("test")
+	protected static class TestProperties {
 
-		private List<String> messages;
+		private String message;
 
 		private int count;
 
-		public List<String> getMessages() {
-			return this.messages;
+		private String name = "default-name";
+
+		public String getMessage() {
+			return this.message;
 		}
 
-		public void setMessages(List<String> messages) {
-			this.messages = messages;
+		public void setMessage(String message) {
+			this.message = message;
 		}
 
 		public int getCount() {
 			return this.count;
 		}
 
-		@Override
-		public void afterPropertiesSet() {
-			this.count++;
+		public void setCount(int count) {
+			this.count = count;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
 		}
 
 	}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderClearIntegrationTests.java
@@ -103,6 +103,22 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 		then(this.properties.getMessage()).isEqualTo("World");
 	}
 
+	@Test
+	@DirtiesContext
+	public void testNestedPropertyWithoutSetterRestoredOnRemoval() {
+		then(this.properties.getNested().getHost()).isEqualTo("default-host");
+		// Set a nested value
+		TestPropertyValues.of("test.nested.host=custom-host").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getNested().getHost()).isEqualTo("custom-host");
+		// Remove the property
+		Map<String, Object> map = findTestProperties();
+		map.remove("test.nested.host");
+		this.rebinder.rebind();
+		// Should revert to nested field initializer default
+		then(this.properties.getNested().getHost()).isEqualTo("default-host");
+	}
+
 	private Map<String, Object> findTestProperties() {
 		for (PropertySource<?> source : this.environment.getPropertySources()) {
 			if (source.getName().toLowerCase().contains("test")) {
@@ -149,6 +165,8 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 		private String name = "default-name";
 
+		private final NestedProperties nested = new NestedProperties();
+
 		public String getMessage() {
 			return this.message;
 		}
@@ -171,6 +189,24 @@ public class ConfigurationPropertiesRebinderClearIntegrationTests {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+
+		public NestedProperties getNested() {
+			return this.nested;
+		}
+
+	}
+
+	protected static class NestedProperties {
+
+		private String host = "default-host";
+
+		public String getHost() {
+			return this.host;
+		}
+
+		public void setHost(String host) {
+			this.host = host;
 		}
 
 	}

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderProxyIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderProxyIntegrationTests.java
@@ -38,11 +38,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@SpringBootTest(classes = TestConfiguration.class, properties = { "messages.expiry.one=168", "messages.expiry.two=76" })
+@SpringBootTest(classes = TestConfiguration.class, properties = { "messages.expiry.one=168", "messages.expiry.two=76",
+		"messages.name=custom", "messages.count=5" })
 public class ConfigurationPropertiesRebinderProxyIntegrationTests {
 
 	@Autowired
@@ -63,6 +65,56 @@ public class ConfigurationPropertiesRebinderProxyIntegrationTests {
 		TestPropertyValues.of("messages.expiry.one=56").applyTo(this.environment);
 		this.rebinder.rebind();
 		then(this.properties.getExpiry().get("one")).isEqualTo(new Integer(56));
+	}
+
+	@Test
+	@DirtiesContext
+	public void testPropertyClearedToNullThroughProxy() {
+		then(this.properties.getName()).isEqualTo("custom");
+		Map<String, Object> map = findTestProperties();
+		map.remove("messages.name");
+		this.rebinder.rebind();
+		then(this.properties.getName()).isNull();
+	}
+
+	@Test
+	@DirtiesContext
+	public void testPrimitivePropertyClearedToDefaultThroughProxy() {
+		then(this.properties.getCount()).isEqualTo(5);
+		Map<String, Object> map = findTestProperties();
+		map.remove("messages.count");
+		this.rebinder.rebind();
+		then(this.properties.getCount()).isEqualTo(0);
+	}
+
+	@Test
+	@DirtiesContext
+	public void testFieldInitializerRestoredThroughProxy() {
+		then(this.properties.getLabel()).isEqualTo("default-label");
+		// Set a value
+		TestPropertyValues.of("messages.label=custom").applyTo(this.environment);
+		this.rebinder.rebind();
+		then(this.properties.getLabel()).isEqualTo("custom");
+		// Remove the property
+		Map<String, Object> map = findTestProperties();
+		map.remove("messages.label");
+		this.rebinder.rebind();
+		// Should revert to field initializer default
+		then(this.properties.getLabel()).isEqualTo("default-label");
+	}
+
+	private Map<String, Object> findTestProperties() {
+		for (PropertySource<?> source : this.environment.getPropertySources()) {
+			if (source.getName().toLowerCase().contains("test")) {
+				Object sourceObj = source.getSource();
+				if (sourceObj instanceof Map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> map = (Map<String, Object>) sourceObj;
+					return map;
+				}
+			}
+		}
+		throw new IllegalStateException("Could not find test property source");
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -109,6 +161,10 @@ public class ConfigurationPropertiesRebinderProxyIntegrationTests {
 
 		private String name;
 
+		private int count;
+
+		private String label = "default-label";
+
 		public Map<String, Integer> getExpiry() {
 			return this.expiry;
 		}
@@ -119,6 +175,22 @@ public class ConfigurationPropertiesRebinderProxyIntegrationTests {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+
+		public int getCount() {
+			return this.count;
+		}
+
+		public void setCount(int count) {
+			this.count = count;
+		}
+
+		public String getLabel() {
+			return this.label;
+		}
+
+		public void setLabel(String label) {
+			this.label = label;
 		}
 
 	}


### PR DESCRIPTION
## Problem

I noticed that when a property is removed from the `Environment` with a property refresh resulting in a specific property going from having a configured value to having no value, the `ConfigurationPropertiesRebinder` effectively only calls the lifecycle methods on the bean, but doesn't reset the values. This results in `@RefreshScope` annotated beans not clearing their configuration leaving potentially orphaned configuration from the prior state.

## Solution

Reset the bean to its default state as if it were going to be a new instance, so that when performing `initializeBean()` on the new instance it is bound with a fresh state. 

I also covered the case where if restoring the bean to its initial state is impossible, the code will be able to gracefully handle that edge case.

## Alternative

Since we're resetting the bean behind a JDK proxy, we could replace the internal value with the brand new instance rather than just a simple value reset.

## Related
- https://github.com/spring-cloud/spring-cloud-commons/issues/1372
- `ConfigurationPropertiesRebinderListIntegrationTests` also had a `@Disabled` test -- `testReplaceProperties` -- which illustrated this inability as well.