### PR TITLE
GH-1644: Document RefreshScopeHealthIndicator

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-commons/application-context-services.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-commons/application-context-services.adoc
@@ -226,6 +226,24 @@ WARNING: Context Refresh is not supported for Spring AOT transformations and nat
 
 Seamlessly refreshing beans on restart is especially useful for applications that run with JVM Checkpoint Restore (such as https://github.com/CRaC[Project CRaC]). To allow this ability, we now instantiate a `RefreshScopeLifecycle` bean that triggers Context Refresh on restart, resulting in rebinding configuration properties and refreshing any beans annotated with `@RefreshScope`. You can disable this behavior by setting `spring.cloud.refresh.on-restart.enabled` to `false`.
 
+[[refresh-scope-health-indicator]]
+=== Refresh Scope Health Indicator
+
+When Spring Cloud Context is on the classpath together with Spring Boot Actuator, a `RefreshScopeHealthIndicator` is auto-configured.
+This health indicator reports `UP` when there are no errors associated with the refresh scope, and `DOWN` (with the error details) when a `@RefreshScope` bean or a `@ConfigurationProperties`-bound bean failed to re-bind after a configuration refresh.
+
+This makes it easy to detect post-refresh failures via the `/actuator/health` endpoint.
+
+To disable the indicator, set the following property:
+
+[source,yaml]
+----
+management:
+  health:
+    refresh:
+      enabled: false
+----
+
 [[encryption-and-decryption]]
 == Encryption and Decryption
 


### PR DESCRIPTION
## Summary

Closes #1644

Adds a `[[refresh-scope-health-indicator]]` subsection to the Refresh Scope section of `application-context-services.adoc` that:

- Documents that `RefreshScopeHealthIndicator` is auto-configured when Spring Boot Actuator is on the classpath
- Explains what it reports: `UP` when no refresh errors exist, `DOWN` with error details when a `@RefreshScope` or `@ConfigurationProperties` bean fails to rebind after a config refresh
- Shows how to disable it: `management.health.refresh.enabled=false`

This follows the same style as the `DiscoveryClientHealthIndicator` documentation in `common-abstractions.adoc`.

The health indicator is wired via `@ConditionalOnEnabledHealthIndicator("refresh")` in `RefreshEndpointAutoConfiguration`, which maps to the `management.health.refresh.enabled` property.

## Test plan

- [ ] AsciiDoc renders the new section correctly under the Refresh Scope section
- [ ] The `management.health.refresh.enabled=false` snippet renders as YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)