### PR TITLE
GH-1644: Document RefreshScopeHealthIndicator and how to disable it

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-commons/application-context-services.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-commons/application-context-services.adoc
@@ -226,6 +226,22 @@ WARNING: Context Refresh is not supported for Spring AOT transformations and nat
 
 Seamlessly refreshing beans on restart is especially useful for applications that run with JVM Checkpoint Restore (such as https://github.com/CRaC[Project CRaC]). To allow this ability, we now instantiate a `RefreshScopeLifecycle` bean that triggers Context Refresh on restart, resulting in rebinding configuration properties and refreshing any beans annotated with `@RefreshScope`. You can disable this behavior by setting `spring.cloud.refresh.on-restart.enabled` to `false`.
 
+[[refresh-scope-health-indicator]]
+=== Health Indicator
+
+Spring Cloud auto-configures a `RefreshScopeHealthIndicator` that monitors the health of the refresh scope.
+If any bean fails to re-initialize or rebind its configuration properties after a context refresh, the indicator transitions to `DOWN` and exposes the relevant exception details.
+
+To disable the health indicator, set:
+
+[source,yaml]
+----
+management:
+  health:
+    refresh:
+      enabled: false
+----
+
 [[encryption-and-decryption]]
 == Encryption and Decryption
 


### PR DESCRIPTION
## Summary

Closes #1644.

The `@RefreshScope` section lacked any mention of the auto-configured `RefreshScopeHealthIndicator`. Users discovering the `refresh` health indicator in their `/actuator/health` output had no documentation explaining its purpose or how to opt out.

This PR adds a **Health Indicator** subsection under *Refresh Scope* that:
- Explains what `RefreshScopeHealthIndicator` does (transitions to `DOWN` when a bean fails to re-initialize or rebind after a context refresh).
- Shows how to disable it via `management.health.refresh.enabled=false`, consistent with the pattern already established in the Discovery Client docs.

## Test plan

- [ ] Documentation renders correctly (AsciiDoc structure is valid)
- [ ] `management.health.refresh.enabled=false` disables the indicator (verified against `RefreshEndpointAutoConfiguration` which uses `@ConditionalOnEnabledHealthIndicator("refresh")`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)