### PR TITLE
Re-enable lifecycle MVC endpoint tests

### DIFF
--- a/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/autoconfigure/LifecycleMvcAutoConfigurationTests.java
@@ -48,7 +48,6 @@ public class LifecycleMvcAutoConfigurationTests {
 	}
 
 	@Test
-	@Disabled("TODO: https://github.com/spring-cloud/spring-cloud-commons/issues/1520")
 	public void environmentWebEndpointExtensionDisabled() {
 		beanNotCreated("writableEnvironmentEndpointWebExtension", "management.endpoint.env.enabled=false");
 	}
@@ -66,7 +65,6 @@ public class LifecycleMvcAutoConfigurationTests {
 
 	// restartEndpoint
 	@Test
-	@Disabled("TODO: https://github.com/spring-cloud/spring-cloud-commons/issues/1520")
 	public void restartEndpointDisabled() {
 		beanNotCreated("restartEndpoint", "management.endpoint.restart.enabled=false");
 	}


### PR DESCRIPTION
This re-enables two LifecycleMvcAutoConfigurationTests methods that were still disabled for gh-1520.

On current main, both disabled checks now pass with the current Spring Boot baseline, so the regression coverage can be restored:

- environmentWebEndpointExtensionDisabled
- restartEndpointDisabled

Validation:

```
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl spring-cloud-context -Dtest=LifecycleMvcAutoConfigurationTests test
```

Result: 14 tests run, 0 failures, 0 errors, 3 skipped.

Fixes gh-1520