### PR TITLE
Use binary class name to resolve per-class HTTP interface fallbacks

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/httpservice/CircuitBreakerRequestValueProcessor.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/circuitbreaker/httpservice/CircuitBreakerRequestValueProcessor.java
@@ -72,7 +72,7 @@ public class CircuitBreakerRequestValueProcessor implements HttpRequestValues.Pr
 		builder.addAttribute(PARAMETER_TYPES_ATTRIBUTE_NAME, method.getParameterTypes());
 		builder.addAttribute(ARGUMENTS_ATTRIBUTE_NAME, arguments);
 		builder.addAttribute(RETURN_TYPE_ATTRIBUTE_NAME, method.getReturnType());
-		builder.addAttribute(DECLARING_CLASS_ATTRIBUTE_NAME, method.getDeclaringClass().getCanonicalName());
+		builder.addAttribute(DECLARING_CLASS_ATTRIBUTE_NAME, method.getDeclaringClass().getName());
 	}
 
 }

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/circuitbreaker/httpservice/CircuitBreakerAdapterDecoratorTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/circuitbreaker/httpservice/CircuitBreakerAdapterDecoratorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.client.circuitbreaker.httpservice;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.service.invoker.HttpExchangeAdapter;
 import org.springframework.web.service.invoker.HttpRequestValues;
 
@@ -126,6 +129,36 @@ class CircuitBreakerAdapterDecoratorTests {
 
 		assertThatExceptionOfType(NoFallbackAvailableException.class)
 			.isThrownBy(() -> fallbackHandler.apply(new RuntimeException("test")));
+	}
+
+	// Fallback classes are registered per service under Class#getName() (binary name),
+	// so the declaring-class attribute written by the processor must use the same form.
+	// For a nested @HttpExchange interface getName() ("Outer$Inner") differs from
+	// getCanonicalName() ("Outer.Inner"), which used to leave the per-class fallback
+	// unresolved and fall through to NoFallbackAvailableException.
+	@Test
+	void shouldResolvePerClassFallbackForNestedServiceInterface() throws NoSuchMethodException {
+		Method method = NestedTestService.class.getMethod("test", String.class, Integer.class);
+		HttpRequestValues.Builder builder = HttpRequestValues.builder();
+		new CircuitBreakerRequestValueProcessor().process(method, new MethodParameter[0],
+				new Object[] { "testDescription", 5 }, builder);
+		builder.setHttpMethod(HttpMethod.GET);
+		builder.setUriTemplate("/test");
+		Map<String, Object> attributes = builder.build().getAttributes();
+		CircuitBreakerAdapterDecorator nestedDecorator = new CircuitBreakerAdapterDecorator(adapter, circuitBreaker,
+				Map.of(NestedTestService.class.getName(), Fallbacks.class));
+		when(httpRequestValues.getAttributes()).thenReturn(attributes);
+		Function<Throwable, Object> fallbackHandler = nestedDecorator.createFallbackHandler(httpRequestValues);
+
+		Object fallback = fallbackHandler.apply(new RuntimeException("test"));
+
+		assertThat(fallback).isEqualTo("testDescription: 5");
+	}
+
+	interface NestedTestService {
+
+		String test(String description, Integer value);
+
 	}
 
 }


### PR DESCRIPTION
## What
`CircuitBreakerRequestValueProcessor` records the declaring class of the invoked `@HttpExchange` method under `getCanonicalName()`, but per-class fallbacks are registered with `Class#getName()` (the binary name) in `CircuitBreakerConfigurerUtils.addFallbackEntries`. `getFallback` then resolves the fallback by looking up that recorded value.

For a top-level interface both forms are identical, but for a **nested** `@HttpExchange` interface they differ: `com.example.Outer.Inner` (canonical) vs `com.example.Outer$Inner` (binary). The lookup key never matches the registration key, so the per-class fallback is silently skipped and the invocation falls through to the `default` fallback or, when none is registered, throws `NoFallbackAvailableException`.

## Fix
Record the declaring class under `getName()` so the declaring-class lookup key matches the registration key. Top-level interfaces are unaffected because their canonical and binary names are identical.

This circuit-breaking-over-`@HttpExchange` support is new in 5.0.0 and unreleased, so aligning the stored attribute carries no compatibility concern.

## Verification
- Added `shouldResolvePerClassFallbackForNestedServiceInterface` to `CircuitBreakerAdapterDecoratorTests`, which drives the real `CircuitBreakerRequestValueProcessor` with a nested service interface and asserts the per-class fallback resolves.
- With the fix reverted the new test fails with `NoFallbackAvailableException`; with the fix the whole test class passes (`Tests run: 6, Failures: 0, Errors: 0`).
- `./mvnw -pl spring-cloud-commons test` is green, including spring-javaformat and checkstyle validation.