### PR TITLE
Autowire beans when rebinding

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinder.java
@@ -174,12 +174,14 @@ public class ConfigurationPropertiesRebinder
 					else {
 						appContext.getAutowireCapableBeanFactory().destroyBean(target);
 						resetBeanToDefaults(target);
+						appContext.getAutowireCapableBeanFactory().autowireBean(target);
 						appContext.getAutowireCapableBeanFactory().initializeBean(target, name);
 					}
 				}
 				else {
 					appContext.getAutowireCapableBeanFactory().destroyBean(bean);
 					resetBeanToDefaults(bean);
+					appContext.getAutowireCapableBeanFactory().autowireBean(bean);
 					appContext.getAutowireCapableBeanFactory().initializeBean(bean, name);
 				}
 				return true;

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderValueFieldIntegrationTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/properties/ConfigurationPropertiesRebinderValueFieldIntegrationTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.properties;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.cloud.context.properties.ConfigurationPropertiesRebinderValueFieldIntegrationTests.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * Verifies that a {@code @Value}-injected field on a non-proxied
+ * {@code @ConfigurationProperties} bean survives a rebind even when the field is not
+ * reachable under the bean's own prefix (for example
+ * {@code ConsulDiscoveryProperties#aclToken}). See gh-1716.
+ *
+ * @author Ryan Baxter
+ */
+@SpringBootTest(classes = TestConfiguration.class, properties = { "test.message=Hello", "secret.token=secret-value" })
+public class ConfigurationPropertiesRebinderValueFieldIntegrationTests {
+
+	@Autowired
+	private TestProperties properties;
+
+	@Autowired
+	private ConfigurationPropertiesRebinder rebinder;
+
+	@Autowired
+	private ConfigurableEnvironment environment;
+
+	@Test
+	@DirtiesContext
+	public void valueInjectedFieldSurvivesRebind() {
+		then(this.properties.getMessage()).isEqualTo("Hello");
+		then(this.properties.getToken()).isEqualTo("secret-value");
+		// Change a property under the bean's own prefix and rebind
+		TestPropertyValues.of("test.message=World").applyTo(this.environment);
+		this.rebinder.rebind();
+		// The rebind picks up the new value under the bean's prefix...
+		then(this.properties.getMessage()).isEqualTo("World");
+		// ...and the @Value field, which is outside that prefix, is not lost
+		then(this.properties.getToken()).isEqualTo("secret-value");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties
+	@Import({ RefreshConfiguration.RebinderConfiguration.class, PropertyPlaceholderAutoConfiguration.class })
+	protected static class TestConfiguration {
+
+		@Bean
+		protected TestProperties testProperties() {
+			return new TestProperties();
+		}
+
+	}
+
+	// Hack out a protected inner class for testing
+	protected static class RefreshConfiguration extends RefreshAutoConfiguration {
+
+		@Configuration(proxyBeanMethods = false)
+		protected static class RebinderConfiguration extends ConfigurationPropertiesRebinderAutoConfiguration {
+
+			public RebinderConfiguration(ApplicationContext context) {
+				super(context);
+			}
+
+		}
+
+	}
+
+	@ConfigurationProperties("test")
+	protected static class TestProperties {
+
+		@Value("${secret.token:}")
+		private String token;
+
+		private String message;
+
+		public String getToken() {
+			return this.token;
+		}
+
+		public void setToken(String token) {
+			this.token = token;
+		}
+
+		public String getMessage() {
+			return this.message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes regressions where @Value annotated properties are reset to null.  Fixes #1716