### PR TITLE
Make GenericScope proxy locking conditional on ScopeCache

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/GenericScope.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/GenericScope.java
@@ -304,12 +304,20 @@ public class GenericScope
 		return this.locks.get(beanName);
 	}
 
+	boolean requiresProxyLocking() {
+		return this.cache.requiresLocking();
+	}
+
 	private static class BeanLifecycleWrapperCache {
 
 		private final ScopeCache cache;
 
 		BeanLifecycleWrapperCache(ScopeCache cache) {
 			this.cache = cache;
+		}
+
+		boolean requiresLocking() {
+			return this.cache.requiresLocking();
 		}
 
 		public BeanLifecycleWrapper remove(String name) {
@@ -368,7 +376,7 @@ public class GenericScope
 
 		public Object getBean() {
 			if (this.bean == null) {
-				synchronized (this.name) {
+				synchronized (this) {
 					if (this.bean == null) {
 						this.bean = this.objectFactory.getObject();
 					}
@@ -381,7 +389,7 @@ public class GenericScope
 			if (this.callback == null) {
 				return;
 			}
-			synchronized (this.name) {
+			synchronized (this) {
 				Runnable callback = this.callback;
 				if (callback != null) {
 					callback.run();
@@ -464,16 +472,19 @@ public class GenericScope
 				return invocation.proceed();
 			}
 			Object proxy = getObject();
-			ReadWriteLock readWriteLock = this.scope.getLock(this.targetBeanName);
-			if (readWriteLock == null) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("For bean with name [" + this.targetBeanName
-							+ "] there is no read write lock. Will create a new one to avoid NPE");
+			Lock lock = null;
+			if (this.scope.requiresProxyLocking()) {
+				ReadWriteLock readWriteLock = this.scope.getLock(this.targetBeanName);
+				if (readWriteLock == null) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("For bean with name [" + this.targetBeanName
+								+ "] there is no read write lock. Will create a new one to avoid NPE");
+					}
+					readWriteLock = new ReentrantReadWriteLock();
 				}
-				readWriteLock = new ReentrantReadWriteLock();
+				lock = readWriteLock.readLock();
+				lock.lock();
 			}
-			Lock lock = readWriteLock.readLock();
-			lock.lock();
 			try {
 				if (proxy instanceof Advised advised) {
 					ReflectionUtils.makeAccessible(method);
@@ -488,7 +499,9 @@ public class GenericScope
 				throw e.getUndeclaredThrowable();
 			}
 			finally {
-				lock.unlock();
+				if (lock != null) {
+					lock.unlock();
+				}
 			}
 		}
 

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/ScopeCache.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/ScopeCache.java
@@ -59,4 +59,16 @@ public interface ScopeCache {
 	 */
 	Object put(String name, Object value);
 
+	/**
+	 * Returns whether instances stored in this cache can be accessed concurrently by
+	 * multiple threads, in which case {@link GenericScope} guards proxied invocations
+	 * with read/write locks to protect them from concurrent destruction. Caches whose
+	 * instances are confined to a single thread (e.g. backed by a thread local) should
+	 * return {@code false} so that locking can be skipped (see gh-630).
+	 * @return whether proxied invocations require locking; default {@code true}
+	 */
+	default boolean requiresLocking() {
+		return true;
+	}
+
 }

--- a/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/thread/ThreadLocalScopeCache.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/context/scope/thread/ThreadLocalScopeCache.java
@@ -58,4 +58,9 @@ public class ThreadLocalScopeCache implements ScopeCache {
 		return value;
 	}
 
+	@Override
+	public boolean requiresLocking() {
+		return false;
+	}
+
 }

--- a/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/GenericScopeLockingTests.java
+++ b/spring-cloud-context/src/test/java/org/springframework/cloud/context/scope/GenericScopeLockingTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.context.scope;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.context.scope.thread.ThreadLocalScopeCache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for gh-630: {@link GenericScope} proxy locking must be driven by the
+ * {@link ScopeCache} in use, so that caches whose instances are confined to a single
+ * thread (e.g. {@link ThreadLocalScopeCache}) are not penalized by name-keyed read/write
+ * locks shared across all scope instances.
+ */
+class GenericScopeLockingTests {
+
+	@Test
+	void standardScopeCacheRequiresLockingByDefault() {
+		assertThat(new StandardScopeCache().requiresLocking()).isTrue();
+	}
+
+	@Test
+	void threadLocalScopeCacheOptsOutOfLocking() {
+		assertThat(new ThreadLocalScopeCache().requiresLocking()).isFalse();
+	}
+
+	@Test
+	void proxiedInvocationsConsultLockWhenCacheRequiresIt() {
+		new ApplicationContextRunner().withUserConfiguration(StandardCacheConfig.class).run((context) -> {
+			Service service = context.getBean(Service.class);
+			assertThat(service.ping()).isEqualTo("pong");
+			CountingScope scope = context.getBean(CountingScope.class);
+			assertThat(scope.lockConsultations.get()).isEqualTo(1);
+		});
+	}
+
+	@Test
+	void proxiedInvocationsSkipLockWhenCacheDoesNotRequireIt() {
+		new ApplicationContextRunner().withUserConfiguration(ThreadLocalCacheConfig.class).run((context) -> {
+			Service service = context.getBean(Service.class);
+			assertThat(service.ping()).isEqualTo("pong");
+			CountingScope scope = context.getBean(CountingScope.class);
+			assertThat(scope.lockConsultations.get()).isZero();
+		});
+	}
+
+	@Test
+	void beanCreationInOneScopeInstanceDoesNotBlockOtherInstancesWithSameBeanName() throws Exception {
+		GenericScope first = new GenericScope();
+		GenericScope second = new GenericScope();
+		CountDownLatch creationStarted = new CountDownLatch(1);
+		CountDownLatch releaseCreation = new CountDownLatch(1);
+		AtomicReference<Object> firstResult = new AtomicReference<>();
+		Thread creator = new Thread(() -> firstResult.set(first.get("shared-name", () -> {
+			creationStarted.countDown();
+			try {
+				releaseCreation.await(30, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException(ex);
+			}
+			return new Object();
+		})));
+		creator.start();
+		assertThat(creationStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+		// While the first scope instance is creating its "shared-name" bean, a second,
+		// independent scope instance must be able to create its own instance of the
+		// same bean name without waiting on the first (gh-630).
+		AtomicReference<Object> secondResult = new AtomicReference<>(null);
+		CountDownLatch secondDone = new CountDownLatch(1);
+		Thread independent = new Thread(() -> {
+			secondResult.set(second.get("shared-name", Object::new));
+			secondDone.countDown();
+		});
+		independent.start();
+
+		boolean unblocked = secondDone.await(10, TimeUnit.SECONDS);
+
+		releaseCreation.countDown();
+		creator.join(TimeUnit.SECONDS.toMillis(5));
+		independent.join(TimeUnit.SECONDS.toMillis(5));
+
+		assertThat(unblocked).as("second scope was blocked by first scope's creation").isTrue();
+		assertThat(secondResult.get()).isNotNull();
+		assertThat(firstResult.get()).isNotNull();
+	}
+
+	interface Service {
+
+		String ping();
+
+	}
+
+	static class SimpleService implements Service {
+
+		@Override
+		public String ping() {
+			return "pong";
+		}
+
+	}
+
+	static class CountingScope extends GenericScope {
+
+		final AtomicInteger lockConsultations = new AtomicInteger();
+
+		@Override
+		protected ReadWriteLock getLock(String beanName) {
+			this.lockConsultations.incrementAndGet();
+			return super.getLock(beanName);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class StandardCacheConfig {
+
+		@Bean
+		static CountingScope genericScope() {
+			CountingScope scope = new CountingScope();
+			scope.setName("standard-cache-scope");
+			scope.setScopeCache(new StandardScopeCache());
+			return scope;
+		}
+
+		@Bean
+		@Scope(value = "standard-cache-scope", proxyMode = ScopedProxyMode.TARGET_CLASS)
+		Service service() {
+			return new SimpleService();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ThreadLocalCacheConfig {
+
+		@Bean
+		static CountingScope genericScope() {
+			CountingScope scope = new CountingScope();
+			scope.setName("thread-local-scope");
+			scope.setScopeCache(new ThreadLocalScopeCache());
+			return scope;
+		}
+
+		@Bean
+		@Scope(value = "thread-local-scope", proxyMode = ScopedProxyMode.TARGET_CLASS)
+		Service service() {
+			return new SimpleService();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Context

`GenericScope` guards every proxied invocation with a read lock keyed by the bean *name*, and `destroy()` takes the matching write lock. Those locks live in a single map on the scope instance, so **all** scope instances sharing one `GenericScope` contend - even when the configured `ScopeCache` confines instances to a single thread (e.g. `ThreadLocalScopeCache`). For message-listener-style usage (one thread-local scope per consumer thread), a single instance's teardown write-locks the bean name for every thread.

The analysis in #630 was endorsed by @dsyer back in 2020:

> The analysis looks good. Do we have a pull request?

Six years later - here is that pull request. Nothing was ever merged in between; the locking code is unchanged since the original 2017 commit referenced in the issue.

## What this PR does

1. **New `ScopeCache.requiresLocking()`** (`default boolean`, returns `true`) documenting the contract: caches whose instances are confined to a single thread return `false`. Concurrency semantics belong to the cache implementation - the reporter's instinct - without contorting the storage-only contract into an invocation-guard.
2. **`ThreadLocalScopeCache` overrides it to `false`**, and `GenericScope`'s `LockedScopedProxyFactoryBean` skips read-lock acquisition entirely when the cache does not require locking. The gh-349 `UndeclaredThrowableException` unwrap is preserved on both paths; destruction-side write locks are intentionally left untouched (uncontended when no readers exist, keeps the diff minimal).
3. **Bonus contention fix in the same spirit:** `BeanLifecycleWrapper` synchronized on `this.name` - a shared, typically-interned String - so independent scope instances creating same-named beans serialized against each other during lazy creation and destruction. The monitor is now the wrapper instance itself, which is exactly the state being guarded. Single-wrapper-per-name-per-cache holds via the existing `putIfAbsent` semantics of both in-tree caches.

## Backward compatibility

- Default behavior is unchanged by construction: `StandardScopeCache` (and therefore `RefreshScope`) never override `requiresLocking()`, so every refresh path keeps identical locking. All existing `RefreshScope*Tests` pass unmodified.
- Adding a default method preserves binary compatibility for already-compiled custom `ScopeCache` implementations.
- No framework-internal code calls `setScopeCache(...)` with a non-default cache today; the affected surface is custom scopes like the reporter's.

## Testing

- New `GenericScopeLockingTests` (first direct test coverage this area has had): contract defaults, proxy invocation consults locks for `StandardScopeCache` / skips for `ThreadLocalScopeCache`, and cross-instance creation of same-named beans proceeds without blocking. Tests went red before the fix (compile gap + behavioral failures on the old `GenericScope`) and green after.
- Full `spring-cloud-context` suite: 232 tests, no failures from this change. (One pre-existing, unrelated error in `EncryptorFactoryTests.testWithRsaPrivateKey` reproduces identically on clean `main`; it is environment-related PEM parsing and untouched here.)

Fixes #630

## Notes for reviewers

- Happy to split the `BeanLifecycleWrapper` monitor-granularity fix into a separate commit/PR if preferred.
- Pre-existing nits observed but deliberately not touched here: non-volatile `callback` field written outside synchronization, and a potential NPE in `destroy(name)` if the lock map lacks an entry.