### PR TITLE
Update latest Spring Antora UI

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -30,4 +30,4 @@ runtime:
     format: pretty
 ui:
   bundle:
-    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.15/ui-bundle.zip
+    url: https://github.com/spring-io/antora-ui-spring/releases/download/latest/ui-bundle.zip


### PR DESCRIPTION
Spring Cloud Commons and the other Spring Cloud projects are still using the old Antora UI. The main difference is the navbar compared to [spring.io](https://spring.io/) and the reference docs.

If this is not intentional, I will create a PR to update the `doc-build` branch.
