### PR TITLE
Respect discovery client order for reactive instance lookup

### DIFF
--- a/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClient.java
+++ b/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClient.java
@@ -16,14 +16,12 @@
 
 package org.springframework.cloud.client.discovery.composite.reactive;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
-import org.springframework.cloud.commons.publisher.CloudFlux;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 /**
@@ -51,11 +49,11 @@ public class ReactiveCompositeDiscoveryClient implements ReactiveDiscoveryClient
 		if (discoveryClients == null || discoveryClients.isEmpty()) {
 			return Flux.empty();
 		}
-		List<Flux<ServiceInstance>> serviceInstances = new ArrayList<>();
+		Flux<ServiceInstance> serviceInstances = Flux.empty();
 		for (ReactiveDiscoveryClient discoveryClient : discoveryClients) {
-			serviceInstances.add(discoveryClient.getInstances(serviceId));
+			serviceInstances = serviceInstances.switchIfEmpty(discoveryClient.getInstances(serviceId));
 		}
-		return CloudFlux.firstNonEmpty(serviceInstances);
+		return serviceInstances;
 	}
 
 	@Override

--- a/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClientTests.java
+++ b/spring-cloud-commons/src/test/java/org/springframework/cloud/client/discovery/composite/reactive/ReactiveCompositeDiscoveryClientTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.cloud.client.discovery.composite.reactive;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.PublisherProbe;
 import reactor.test.publisher.TestPublisher;
 
 import org.springframework.cloud.client.DefaultServiceInstance;
@@ -119,6 +122,59 @@ class ReactiveCompositeDiscoveryClientTests {
 			.expectNext(serviceInstance2)
 			.expectComplete()
 			.verify();
+	}
+
+	@Test
+	void shouldPreferOrderedClientEvenWhenItsResponseIsDelayed() {
+		ServiceInstance preferred = new DefaultServiceInstance("preferred", "service", "localhost", 8080, false);
+		ServiceInstance second = new DefaultServiceInstance("second", "service", "localhost", 8081, false);
+		PublisherProbe<ServiceInstance> fallback = PublisherProbe.of(Flux.just(second));
+		when(discoveryClient1.getOrder()).thenReturn(-1);
+		when(discoveryClient1.getInstances("service"))
+			.thenAnswer(invocation -> Flux.just(preferred, second).delayElements(Duration.ofSeconds(1)));
+		when(discoveryClient2.getInstances("service")).thenReturn(fallback.flux());
+		ReactiveCompositeDiscoveryClient client = new ReactiveCompositeDiscoveryClient(
+				asList(discoveryClient2, discoveryClient1));
+
+		StepVerifier.withVirtualTime(() -> client.getInstances("service"))
+			.thenAwait(Duration.ofSeconds(2))
+			.expectNext(preferred, second)
+			.verifyComplete();
+		fallback.assertWasNotSubscribed();
+	}
+
+	@Test
+	void shouldFallBackWhenPreferredClientIsEmpty() {
+		ServiceInstance instance = new DefaultServiceInstance("instance", "service", "localhost", 8080, false);
+		when(discoveryClient1.getInstances("service")).thenReturn(Flux.empty());
+		when(discoveryClient2.getInstances("service")).thenReturn(Flux.just(instance));
+		ReactiveCompositeDiscoveryClient client = new ReactiveCompositeDiscoveryClient(
+				asList(discoveryClient1, discoveryClient2));
+
+		StepVerifier.create(client.getInstances("service")).expectNext(instance).verifyComplete();
+	}
+
+	@Test
+	void shouldPropagatePreferredClientErrorWithoutSubscribingToFallback() {
+		IllegalStateException error = new IllegalStateException("discovery failed");
+		PublisherProbe<ServiceInstance> fallback = PublisherProbe.empty();
+		when(discoveryClient1.getInstances("service")).thenReturn(Flux.error(error));
+		when(discoveryClient2.getInstances("service")).thenReturn(fallback.flux());
+		ReactiveCompositeDiscoveryClient client = new ReactiveCompositeDiscoveryClient(
+				asList(discoveryClient1, discoveryClient2));
+
+		StepVerifier.create(client.getInstances("service")).expectErrorMatches(actual -> actual == error).verify();
+		fallback.assertWasNotSubscribed();
+	}
+
+	@Test
+	void shouldCompleteWhenAllClientsAreEmpty() {
+		when(discoveryClient1.getInstances("service")).thenReturn(Flux.empty());
+		when(discoveryClient2.getInstances("service")).thenReturn(Flux.empty());
+		ReactiveCompositeDiscoveryClient client = new ReactiveCompositeDiscoveryClient(
+				asList(discoveryClient1, discoveryClient2));
+
+		StepVerifier.create(client.getInstances("service")).verifyComplete();
 	}
 
 }


### PR DESCRIPTION
When a higher-priority discovery client responds slowly, `ReactiveCompositeDiscoveryClient` currently returns the faster lower-priority client's instances. This contradicts the ordering applied in its constructor and the behavior of `CompositeDiscoveryClient`.

Try the publishers in order with `switchIfEmpty`, falling back only when a client completes without instances. The result stays streaming and preserves all instances from the first non-empty client. The shared `CloudFlux` behavior is unchanged.

Fixes #1542.

Validation on JDK 21:

```sh
./mvnw -B -ntp -pl spring-cloud-commons -am test \
  -Dtest=ReactiveCompositeDiscoveryClientTests,ReactiveCompositeDiscoveryClientAutoConfigurationTests,CompositeDiscoveryClientUnitTests \
  -Dsurefire.failIfNoSpecifiedTests=false
```

14 tests passed, with formatting and Checkstyle checks enabled. The delayed-priority regression failed on the original implementation. Coverage also includes empty fallback, multiple instances, error propagation, and not subscribing to lower-priority publishers once a result is found. The full repository suite was not run.

Developed with Codex assistance; the diff and regression results were reviewed.
